### PR TITLE
refactor(client): rename misnamed vertex-decl APIs

### DIFF
--- a/Lead-Client-Source/EterGrnLib/ModelInstanceRender.cpp
+++ b/Lead-Client-Source/EterGrnLib/ModelInstanceRender.cpp
@@ -28,7 +28,7 @@ void CGrannyModelInstance::RenderWithOneTexture()
 	if (IsEmpty())
 		return;
 
-	STATEMANAGER.SetVertexDeclaration(ms_pntVS);
+	STATEMANAGER.SetVertexDeclaration(ms_pntDecl);
 
 	// WORK
 	LPDIRECT3DVERTEXBUFFER9 lpd3dDeformPNTVtxBuf = __GetDeformableD3DVertexBufferPtr();
@@ -58,7 +58,7 @@ void CGrannyModelInstance::BlendRenderWithOneTexture()
 	// END_OF_WORK
 	LPDIRECT3DVERTEXBUFFER9 lpd3dRigidPNTVtxBuf = m_pModel->GetPNTD3DVertexBuffer();
 
-	STATEMANAGER.SetVertexDeclaration(ms_pntVS);
+	STATEMANAGER.SetVertexDeclaration(ms_pntDecl);
 
 	if (lpd3dDeformPNTVtxBuf)
 	{
@@ -80,7 +80,7 @@ void CGrannyModelInstance::RenderWithTwoTexture()
 	if (IsEmpty())
 		return;
 
-	STATEMANAGER.SetVertexDeclaration(ms_pntVS);
+	STATEMANAGER.SetVertexDeclaration(ms_pntDecl);
 
 	// WORK
 	LPDIRECT3DVERTEXBUFFER9 lpd3dDeformPNTVtxBuf = __GetDeformableD3DVertexBufferPtr();
@@ -109,7 +109,7 @@ void CGrannyModelInstance::BlendRenderWithTwoTexture()
 	// END_OF_WORK
 	LPDIRECT3DVERTEXBUFFER9 lpd3dRigidPNTVtxBuf = m_pModel->GetPNTD3DVertexBuffer();
 
-	STATEMANAGER.SetVertexDeclaration(ms_pntVS);
+	STATEMANAGER.SetVertexDeclaration(ms_pntDecl);
 
 	if (lpd3dDeformPNTVtxBuf)
 	{
@@ -129,7 +129,7 @@ void CGrannyModelInstance::RenderWithoutTexture()
 	if (IsEmpty())
 		return;
 
-	STATEMANAGER.SetVertexDeclaration(ms_pntVS);
+	STATEMANAGER.SetVertexDeclaration(ms_pntDecl);
 	STATEMANAGER.SetTexture(0, NULL);
 	STATEMANAGER.SetTexture(1, NULL);
 
@@ -342,7 +342,7 @@ void CGrannyModelInstance::RenderToShadowMap()
 	if (IsEmpty())
 		return;
 
-	STATEMANAGER.SetVertexShader(ms_pntVS);
+	STATEMANAGER.SetVertexShader(ms_pntDecl);
 
 // 	LPDIRECT3DVERTEXBUFFER8 lpd3dDynamicPNTVtxBuf = m_dynamicPNTVtxBuf.GetD3DVertexBuffer();
 	LPDIRECT3DVERTEXBUFFER8 lpd3dDeformPNTVtxBuf = m_dynamicPNTVtxBuf.GetD3DVertexBuffer();

--- a/Lead-Client-Source/EterLib/GrpBase.cpp
+++ b/Lead-Client-Source/EterLib/GrpBase.cpp
@@ -44,9 +44,9 @@ D3DCAPS9				CGraphicBase::ms_d3dCaps;
 
 DWORD					CGraphicBase::ms_dwD3DBehavior = 0;
 
-LPDIRECT3DVERTEXDECLARATION9 CGraphicBase::ms_ptVS = 0;
-LPDIRECT3DVERTEXDECLARATION9 CGraphicBase::ms_pntVS = 0;
-LPDIRECT3DVERTEXDECLARATION9 CGraphicBase::ms_pnt2VS = 0;
+LPDIRECT3DVERTEXDECLARATION9 CGraphicBase::ms_ptDecl = 0;
+LPDIRECT3DVERTEXDECLARATION9 CGraphicBase::ms_pntDecl = 0;
+LPDIRECT3DVERTEXDECLARATION9 CGraphicBase::ms_pnt2Decl = 0;
 
 D3DXMATRIX				CGraphicBase::ms_matIdentity;
 

--- a/Lead-Client-Source/EterLib/GrpBase.h
+++ b/Lead-Client-Source/EterLib/GrpBase.h
@@ -260,9 +260,9 @@ class CGraphicBase
 		static D3DPRESENT_PARAMETERS	ms_d3dPresentParameter;
 		
 		static DWORD					ms_dwD3DBehavior;
-		static LPDIRECT3DVERTEXDECLARATION9 ms_ptVS;
-		static LPDIRECT3DVERTEXDECLARATION9 ms_pntVS;
-		static LPDIRECT3DVERTEXDECLARATION9 ms_pnt2VS;
+		static LPDIRECT3DVERTEXDECLARATION9 ms_ptDecl;
+		static LPDIRECT3DVERTEXDECLARATION9 ms_pntDecl;
+		static LPDIRECT3DVERTEXDECLARATION9 ms_pnt2Decl;
 
 		static D3DXMATRIX				ms_matScreen0;
 		static D3DXMATRIX				ms_matScreen1;

--- a/Lead-Client-Source/EterLib/GrpDevice.cpp
+++ b/Lead-Client-Source/EterLib/GrpDevice.cpp
@@ -135,7 +135,7 @@ bool CGraphicDevice::ResizeBackBuffer(UINT uWidth, UINT uHeight)
 	return true;
 }
 
-LPDIRECT3DVERTEXDECLARATION9 CGraphicDevice::CreatePNTStreamVertexShader()
+LPDIRECT3DVERTEXDECLARATION9 CGraphicDevice::CreatePNTStreamVertexDeclaration()
 {
 	assert(ms_lpd3dDevice != NULL);
 
@@ -151,14 +151,14 @@ LPDIRECT3DVERTEXDECLARATION9 CGraphicDevice::CreatePNTStreamVertexShader()
 	if (ms_lpd3dDevice->CreateVertexDeclaration(pShaderDecl, &dwShader) != D3D_OK)
 	{
 		char szError[1024];
-		sprintf_s(szError, sizeof(szError), "Failed to create CreatePNTStreamVertexShader");
+		sprintf_s(szError, sizeof(szError), "Failed to create CreatePNTStreamVertexDeclaration");
 		MessageBox(NULL, szError, "Vertex Shader Error", MB_ICONSTOP);
 	}
 
 	return dwShader;
 }
 
-LPDIRECT3DVERTEXDECLARATION9 CGraphicDevice::CreatePNT2StreamVertexShader()
+LPDIRECT3DVERTEXDECLARATION9 CGraphicDevice::CreatePNT2StreamVertexDeclaration()
 {
 	assert(ms_lpd3dDevice != NULL);
 
@@ -175,14 +175,14 @@ LPDIRECT3DVERTEXDECLARATION9 CGraphicDevice::CreatePNT2StreamVertexShader()
 	if (ms_lpd3dDevice->CreateVertexDeclaration(pShaderDecl, &dwShader) != D3D_OK)
 	{
 		char szError[1024];
-		sprintf_s(szError, sizeof(szError), "Failed to create CreatePNT2StreamVertexShader");
+		sprintf_s(szError, sizeof(szError), "Failed to create CreatePNT2StreamVertexDeclaration");
 		MessageBox(NULL, szError, "Vertex Shader Error", MB_ICONSTOP);
 	}
 
 	return dwShader;
 }
 
-LPDIRECT3DVERTEXDECLARATION9 CGraphicDevice::CreatePTStreamVertexShader()
+LPDIRECT3DVERTEXDECLARATION9 CGraphicDevice::CreatePTStreamVertexDeclaration()
 {
 	assert(ms_lpd3dDevice != NULL);
 
@@ -197,14 +197,14 @@ LPDIRECT3DVERTEXDECLARATION9 CGraphicDevice::CreatePTStreamVertexShader()
 	if (ms_lpd3dDevice->CreateVertexDeclaration(pShaderDecl, &dwShader) != D3D_OK)
 	{
 		char szError[1024];
-		sprintf_s(szError, sizeof(szError), "Failed to create CreatePTStreamVertexShader");
+		sprintf_s(szError, sizeof(szError), "Failed to create CreatePTStreamVertexDeclaration");
 		MessageBox(NULL, szError, "Vertex Shader Error", MB_ICONSTOP);
 	}
 
 	return dwShader;
 }
 
-LPDIRECT3DVERTEXDECLARATION9 CGraphicDevice::CreateDoublePNTStreamVertexShader()
+LPDIRECT3DVERTEXDECLARATION9 CGraphicDevice::CreateDoublePNTStreamVertexDeclaration()
 {
 	assert(ms_lpd3dDevice != NULL);
 
@@ -224,7 +224,7 @@ LPDIRECT3DVERTEXDECLARATION9 CGraphicDevice::CreateDoublePNTStreamVertexShader()
 	if (ms_lpd3dDevice->CreateVertexDeclaration(pShaderDecl, &dwShader) != D3D_OK)
 	{
 		char szError[1024];
-		sprintf_s(szError, sizeof(szError), "Failed to create CreateDoublePNTStreamVertexShader");
+		sprintf_s(szError, sizeof(szError), "Failed to create CreateDoublePNTStreamVertexDeclaration");
 		MessageBox(NULL, szError, "Vertex Shader Error", MB_ICONSTOP);
 	}
 
@@ -555,9 +555,9 @@ RETRY:
 	D3DXCreateMatrixStack(0, &ms_lpd3dMatStack);
 	ms_lpd3dMatStack->LoadIdentity();
 
-	ms_ptVS	= CreatePTStreamVertexShader();
-	ms_pntVS = CreatePNTStreamVertexShader();
-	ms_pnt2VS = CreatePNT2StreamVertexShader();
+	ms_ptDecl	= CreatePTStreamVertexDeclaration();
+	ms_pntDecl = CreatePNTStreamVertexDeclaration();
+	ms_pnt2Decl = CreatePNT2StreamVertexDeclaration();
 
 	D3DXMatrixIdentity(&ms_matIdentity);
 	D3DXMatrixIdentity(&ms_matView);
@@ -768,22 +768,22 @@ void CGraphicDevice::Destroy()
 		ms_hDC = NULL;
 	}
 
-	if (ms_ptVS)
+	if (ms_ptDecl)
 	{	
-		ms_ptVS->Release();
-		ms_ptVS = 0;;
+		ms_ptDecl->Release();
+		ms_ptDecl = 0;;
 	}
 
-	if (ms_pntVS)
+	if (ms_pntDecl)
 	{
-		ms_pntVS->Release();
-		ms_pntVS = 0;
+		ms_pntDecl->Release();
+		ms_pntDecl = 0;
 	}
 
-	if (ms_pnt2VS)
+	if (ms_pnt2Decl)
 	{
-		ms_pnt2VS->Release();
-		ms_pnt2VS = 0;
+		ms_pnt2Decl->Release();
+		ms_pnt2Decl = 0;
 	}
 
 	safe_release(ms_lpSphereMesh);

--- a/Lead-Client-Source/EterLib/GrpDevice.h
+++ b/Lead-Client-Source/EterLib/GrpDevice.h
@@ -54,10 +54,10 @@ protected:
 	void __DestroyPDTVertexBufferList();
 	bool __CreatePDTVertexBufferList();
 
-	LPDIRECT3DVERTEXDECLARATION9 CreatePTStreamVertexShader();
-	LPDIRECT3DVERTEXDECLARATION9 CreatePNTStreamVertexShader();
-	LPDIRECT3DVERTEXDECLARATION9 CreatePNT2StreamVertexShader();
-	LPDIRECT3DVERTEXDECLARATION9 CreateDoublePNTStreamVertexShader();
+	LPDIRECT3DVERTEXDECLARATION9 CreatePTStreamVertexDeclaration();
+	LPDIRECT3DVERTEXDECLARATION9 CreatePNTStreamVertexDeclaration();
+	LPDIRECT3DVERTEXDECLARATION9 CreatePNT2StreamVertexDeclaration();
+	LPDIRECT3DVERTEXDECLARATION9 CreateDoublePNTStreamVertexDeclaration();
 
 protected:
 	DWORD						m_uBackBufferCount;

--- a/Lead-Client-Source/EterPythonLib/PythonGraphic.cpp
+++ b/Lead-Client-Source/EterPythonLib/PythonGraphic.cpp
@@ -483,7 +483,7 @@ void CPythonGraphic::RenderAlphaImage(CGraphicImageInstance* pImageInstance, flo
 	vertices[3].diffuse = DiffuseColor2;
 	vertices[3].texCoord = TTextureCoordinate(eu, ev);
 
-	STATEMANAGER.SetVertexDeclaration(ms_pntVS);
+	STATEMANAGER.SetVertexDeclaration(ms_pntDecl);
 	// 2004.11.18.myevan.DrawIndexPrimitiveUP -> DynamicVertexBuffer
 	CGraphicBase::SetDefaultIndexBuffer(DEFAULT_IB_FILL_RECT);
 	if (CGraphicBase::SetPDTStream(vertices, 4))

--- a/Lead-Client-Source/GameLib/DungeonBlock.cpp
+++ b/Lead-Client-Source/GameLib/DungeonBlock.cpp
@@ -14,7 +14,7 @@ class CDungeonModelInstance : public CGrannyModelInstance
 			if (IsEmpty())
 				return;
 
-			STATEMANAGER.SetVertexDeclaration(ms_pnt2VS);
+			STATEMANAGER.SetVertexDeclaration(ms_pnt2Decl);
 			LPDIRECT3DVERTEXBUFFER9 lpd3dRigidPNTVtxBuf = m_pModel->GetPNTD3DVertexBuffer();
 			if (lpd3dRigidPNTVtxBuf)
 			{
@@ -36,7 +36,7 @@ class CDungeonModelInstance : public CGrannyModelInstance
 			STATEMANAGER.SaveRenderState(D3DRS_SRCBLEND, D3DBLEND_ZERO);
 			STATEMANAGER.SaveRenderState(D3DRS_DESTBLEND, D3DBLEND_SRCCOLOR);
 
-			STATEMANAGER.SetVertexDeclaration(ms_pnt2VS);
+			STATEMANAGER.SetVertexDeclaration(ms_pnt2Decl);
 			LPDIRECT3DVERTEXBUFFER9 lpd3dRigidPNTVtxBuf = m_pModel->GetPNTD3DVertexBuffer();
 			if (lpd3dRigidPNTVtxBuf)
 			{


### PR DESCRIPTION
Rename Create*StreamVertexShader -> Create*StreamVertexDeclaration and the ms_*VS statics to ms_*Decl (they are vertex declarations, not shaders). Pure rename, behaviour identical. Release|x64 builds 0/0.