### PR TITLE
chore(client): drop obsolete SIS/3dfx driver hacks

### DIFF
--- a/Lead-Client-Source/EterLib/GrpDevice.cpp
+++ b/Lead-Client-Source/EterLib/GrpDevice.cpp
@@ -605,21 +605,6 @@ RETRY:
 	else
 		GRAPHICS_CAPS_CAN_NOT_TEXTURE_ADDRESS_BORDER=true;
 
-	//D3DADAPTER_IDENTIFIER8& d3dAdapterId=pkD3DAdapterInfo->GetIdentifier();
-	if (strnicmp(d3dAdapterId.Driver, "SIS", 3) == 0)
-	{
-		GRAPHICS_CAPS_CAN_NOT_DRAW_LINE = true;
-		GRAPHICS_CAPS_CAN_NOT_DRAW_SHADOW = true;
-		GRAPHICS_CAPS_HALF_SIZE_IMAGE = true;
-		ms_isLowTextureMemory = true;
-	}
-	else if (strnicmp(d3dAdapterId.Driver, "3dfx", 4) == 0)
-	{
-		GRAPHICS_CAPS_CAN_NOT_DRAW_SHADOW = true;
-		GRAPHICS_CAPS_HALF_SIZE_IMAGE = true;
-		ms_isLowTextureMemory = true;
-	}
-
 	return (iRet);
 }
 


### PR DESCRIPTION
Remove the SIS/3dfx ancient-driver workaround block (the sole trigger for the half-size-image, low-texture-memory, and can't-draw-line/shadow caps). Those GPUs predate DX12; the flags now stay at their false defaults. Behaviour-identical on modern hardware. Release|x64 builds 0/0.