### PR TITLE
fix(client): stop Release crash (disable ASLR, guard div0)

### DIFF
--- a/Lead-Client-Source/UserInterface/PythonApplication.cpp
+++ b/Lead-Client-Source/UserInterface/PythonApplication.cpp
@@ -493,7 +493,7 @@ bool CPythonApplication::Process()
 					m_dwFaceAccCount += dwCurFaceCount;
 					m_dwFaceAccTime += m_dwCurRenderTime;
 
-					m_fFaceSpd=static_cast<float>(m_dwFaceAccCount/m_dwFaceAccTime);
+					m_fFaceSpd=(0 != m_dwFaceAccTime) ? static_cast<float>(m_dwFaceAccCount/m_dwFaceAccTime) : 0.0f;
 
 					// Distance automatic adjustment
 					if (-1 == m_iForceSightRange)

--- a/Lead-Client-Source/UserInterface/UserInterface.vcxproj
+++ b/Lead-Client-Source/UserInterface/UserInterface.vcxproj
@@ -173,6 +173,7 @@
       <LinkTimeCodeGeneration />
       <TargetMachine>MachineX64</TargetMachine>
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
+      <RandomizedBaseAddress>false</RandomizedBaseAddress>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
The Release x64 client crashed at map load where Debug did not. Debug already builds with `RandomizedBaseAddress=false`; Release did not, so with ASLR on the process was placed above 4 GB and hit a latent 32-bit pointer truncation, faulting on map load. Disabling ASLR in Release matches Debug and keeps the process in the low 4 GB, so it no longer crashes. (The underlying truncation should still be hunted down and fixed properly.)

Also guards an integer divide-by-zero in `CPythonApplication::Process` (`m_dwFaceAccTime` is 0 on fast machines where a frame rounds to 0 ms).

Release|x64 builds 0 warnings / 0 errors. Verified in-game (login, world, movement).
