### PR TITLE
fix(client): stop x64 crash from truncated Python handles

### DIFF
--- a/Lead-Client-Source/UserInterface/PythonApplicationModule.cpp
+++ b/Lead-Client-Source/UserInterface/PythonApplicationModule.cpp
@@ -1039,16 +1039,16 @@ PyObject * appOpenTextFile(PyObject * poSelf, PyObject * poArgs)
 
 	CTextLineLoader * pTextLineLoader = new CTextLineLoader(szFileName);
 
-	return Py_BuildValue("i", (int)(uintptr_t)pTextLineLoader);
+	return Py_BuildHandle(pTextLineLoader);
 }
 
 PyObject * appCloseTextFile(PyObject * poSelf, PyObject * poArgs)
 {
-	int iHandle;
-	if (!PyTuple_GetInteger(poArgs, 0, &iHandle))
+	void * pvHandle;
+	if (!PyTuple_GetHandle(poArgs, 0, &pvHandle))
 		return Py_BuildException();
 
-	CTextLineLoader * pTextFileLoader = (CTextLineLoader *)(uintptr_t)iHandle;
+	CTextLineLoader * pTextFileLoader = (CTextLineLoader *)pvHandle;
 	delete pTextFileLoader;
 
 	return Py_BuildNone();
@@ -1056,24 +1056,24 @@ PyObject * appCloseTextFile(PyObject * poSelf, PyObject * poArgs)
 
 PyObject * appGetTextFileLineCount(PyObject * poSelf, PyObject * poArgs)
 {
-	int iHandle;
-	if (!PyTuple_GetInteger(poArgs, 0, &iHandle))
+	void * pvHandle;
+	if (!PyTuple_GetHandle(poArgs, 0, &pvHandle))
 		return Py_BuildException();
 
-	CTextLineLoader * pTextFileLoader = (CTextLineLoader *)(uintptr_t)iHandle;
+	CTextLineLoader * pTextFileLoader = (CTextLineLoader *)pvHandle;
 	return Py_BuildValue("i", pTextFileLoader->GetLineCount());
 }
 
 PyObject * appGetTextFileLine(PyObject * poSelf, PyObject * poArgs)
 {
-	int iHandle;
-	if (!PyTuple_GetInteger(poArgs, 0, &iHandle))
+	void * pvHandle;
+	if (!PyTuple_GetHandle(poArgs, 0, &pvHandle))
 		return Py_BuildException();
 	int iLineIndex;
 	if (!PyTuple_GetInteger(poArgs, 1, &iLineIndex))
 		return Py_BuildException();
 
-	CTextLineLoader * pTextFileLoader = (CTextLineLoader *)(uintptr_t)iHandle;
+	CTextLineLoader * pTextFileLoader = (CTextLineLoader *)pvHandle;
 	return Py_BuildValue("s", pTextFileLoader->GetLine(iLineIndex));
 }
 

--- a/Lead-Client-Source/UserInterface/PythonPlayerModule.cpp
+++ b/Lead-Client-Source/UserInterface/PythonPlayerModule.cpp
@@ -1900,9 +1900,9 @@ PyObject * playerGetEmotionIconImage(PyObject* poSelf, PyObject* poArgs)
 		return Py_BuildException();
 
 	if (m_kMap_iEmotionIndex_pkIconImage.end() == m_kMap_iEmotionIndex_pkIconImage.find(iIndex))
-		return Py_BuildValue("i", 0);
+		return Py_BuildHandle(NULL);
 
-	return Py_BuildValue("i", m_kMap_iEmotionIndex_pkIconImage[iIndex]);
+	return Py_BuildHandle(m_kMap_iEmotionIndex_pkIconImage[iIndex]);
 }
 
 PyObject * playerSetItemData(PyObject* poSelf, PyObject* poArgs)

--- a/Lead-Client-Source/UserInterface/PythonQuest.cpp
+++ b/Lead-Client-Source/UserInterface/PythonQuest.cpp
@@ -188,8 +188,8 @@ PyObject * questGetQuestData(PyObject * poSelf, PyObject * poArgs)
 		}
 	}
 
-	return Py_BuildValue("sisi",	pQuestInstance->strTitle.c_str(),
-									pImage,
+	return Py_BuildValue("sNsi",	pQuestInstance->strTitle.c_str(),
+									Py_BuildHandle(pImage),
 									pQuestInstance->strCounterName.c_str(),
 									pQuestInstance->iCounterValue);
 }


### PR DESCRIPTION
Three Python bindings packed a raw C++ pointer into Python as a 32-bit int (`Py_BuildValue("i", ptr)`), bypassing the 64-bit-safe `Py_BuildHandle`. On x64 with ASLR the heap lives above 4GB, so the high 32 bits were dropped and the reconstructed pointer faulted (access violation) when dereferenced:

- `PythonApplicationModule.cpp` — `CTextLineLoader*` text-file handles (open/close/lineCount/getLine), triggered by guild-building data load on entering the game
- `PythonPlayerModule.cpp` — `playerGetEmotionIconImage` emotion-icon `CGraphicImage*`
- `PythonQuest.cpp` — `questGetQuestData` quest-icon `CGraphicImage*`

All three now use `Py_BuildHandle`/`PyTuple_GetHandle`, like the rest of the engine. ASLR stays enabled. Release|x64 builds 0/0; verified in-world.
