### PR TITLE
feat(client): add StateManager::LightEnable and funnel all call sites

### DIFF
--- a/Lead-Client-Source/EterLib/GrpLightManager.cpp
+++ b/Lead-Client-Source/EterLib/GrpLightManager.cpp
@@ -208,7 +208,7 @@ void CLight::SetDeviceLight(BOOL bActive)
 	}
 	if (ms_lpd3dDevice)
 	{
-		ms_lpd3dDevice->LightEnable(m_LightID, bActive);
+		STATEMANAGER.LightEnable(m_LightID, bActive);
 	}
 }
 

--- a/Lead-Client-Source/EterLib/StateManager.cpp
+++ b/Lead-Client-Source/EterLib/StateManager.cpp
@@ -11,6 +11,7 @@ struct SLightData
 		LIGHT_NUM = 8,
 	};
 	D3DLIGHT9 m_akD3DLight[LIGHT_NUM];
+	BOOL m_abLightEnable[LIGHT_NUM];
 } m_kLightData;
 
 
@@ -21,6 +22,14 @@ void CStateManager::SetLight(DWORD index, CONST D3DLIGHT9* pLight)
 	m_kLightData.m_akD3DLight[index]=*pLight;
 
 	m_lpD3DDev->SetLight(index, pLight);
+}
+
+void CStateManager::LightEnable(DWORD index, BOOL bEnable)
+{
+	assert(index<SLightData::LIGHT_NUM);
+	m_kLightData.m_abLightEnable[index]=bEnable;
+
+	m_lpD3DDev->LightEnable(index, bEnable);
 }
 
 void CStateManager::GetLight(DWORD index, D3DLIGHT9* pLight)

--- a/Lead-Client-Source/EterLib/StateManager.h
+++ b/Lead-Client-Source/EterLib/StateManager.h
@@ -255,6 +255,7 @@ class CStateManager : public CSingleton<CStateManager>
 
 		void	SetLight(DWORD index, CONST D3DLIGHT9* pLight);
 		void	GetLight(DWORD index, D3DLIGHT9* pLight);
+		void	LightEnable(DWORD index, BOOL bEnable);
 
 		// Renderstates
 		void	SaveRenderState(D3DRENDERSTATETYPE Type, DWORD dwValue);

--- a/Lead-Client-Source/EterPythonLib/PythonGraphic.cpp
+++ b/Lead-Client-Source/EterPythonLib/PythonGraphic.cpp
@@ -83,7 +83,7 @@ void CPythonGraphic::SetOmniLight()
 	Light.Ambient.a = 1.0f;
     Light.Range = 500.0f;
 	ms_lpd3dDevice->SetLight(0, &Light);
-	ms_lpd3dDevice->LightEnable(0, TRUE);
+	STATEMANAGER.LightEnable(0, TRUE);
 
 	Light.Type = D3DLIGHT_POINT;
 	Light.Position = D3DXVECTOR3(0.0f, 200.0f, 200.0f);
@@ -91,7 +91,7 @@ void CPythonGraphic::SetOmniLight()
 	Light.Attenuation1 = 0.01f;
 	Light.Attenuation2 = 0.0f;
 	ms_lpd3dDevice->SetLight(1, &Light);
-	ms_lpd3dDevice->LightEnable(1, TRUE);
+	STATEMANAGER.LightEnable(1, TRUE);
 }
 
 void CPythonGraphic::SetViewport(float fx, float fy, float fWidth, float fHeight)

--- a/Lead-Client-Source/GameLib/MapManager.cpp
+++ b/Lead-Client-Source/GameLib/MapManager.cpp
@@ -239,12 +239,12 @@ void CMapManager::BeginEnvironment()
 	// Directional Light
 	if (mc_pcurEnvironmentData->bDirLightsEnable[ENV_DIRLIGHT_BACKGROUND])
 	{
-		ms_lpd3dDevice->LightEnable(0, TRUE);
+		STATEMANAGER.LightEnable(0, TRUE);
 
 		rkMap.ApplyLight((DWORD_PTR)mc_pcurEnvironmentData, mc_pcurEnvironmentData->DirLights[ENV_DIRLIGHT_BACKGROUND]);
 	}
 	else
-		ms_lpd3dDevice->LightEnable(0, FALSE);
+		STATEMANAGER.LightEnable(0, FALSE);
 
 	if (mc_pcurEnvironmentData->bFogEnable)
 	{


### PR DESCRIPTION
Adds CStateManager::LightEnable (pass-through + cached enable state, mirroring SetLight) and routes the five raw device->LightEnable sites through it (GrpLightManager, PythonGraphic, MapManager). No raw LightEnable calls remain outside the wrapper.

Part of the DX9→DX12 migration (13). Independent. Debug|x64 builds 0/0.
