### PR TITLE
feat(client): add StateManager Clear and viewport wrappers

### DIFF
--- a/Lead-Client-Source/EterLib/GrpScreen.cpp
+++ b/Lead-Client-Source/EterLib/GrpScreen.cpp
@@ -618,13 +618,13 @@ void CScreen::SetClearStencil(DWORD stencil)
 void CScreen::ClearDepthBuffer()
 {
 	assert(ms_lpd3dDevice != NULL);
-	ms_lpd3dDevice->Clear(0L, NULL, D3DCLEAR_ZBUFFER, ms_clearColor, ms_clearDepth, ms_clearStencil);
+	STATEMANAGER.Clear(D3DCLEAR_ZBUFFER, ms_clearColor, ms_clearDepth, ms_clearStencil);
 }
 
 void CScreen::Clear()
 {
 	assert(ms_lpd3dDevice != NULL);
-	ms_lpd3dDevice->Clear(0L, NULL, D3DCLEAR_TARGET | D3DCLEAR_ZBUFFER, ms_clearColor, ms_clearDepth, ms_clearStencil);
+	STATEMANAGER.Clear(D3DCLEAR_TARGET | D3DCLEAR_ZBUFFER, ms_clearColor, ms_clearDepth, ms_clearStencil);
 }
 
 BOOL CScreen::IsLostDevice()

--- a/Lead-Client-Source/EterLib/StateManager.cpp
+++ b/Lead-Client-Source/EterLib/StateManager.cpp
@@ -23,6 +23,31 @@ void CStateManager::SetLight(DWORD index, CONST D3DLIGHT9* pLight)
 	m_lpD3DDev->SetLight(index, pLight);
 }
 
+HRESULT CStateManager::Clear(DWORD Flags, D3DCOLOR Color, float Z, DWORD Stencil)
+{
+	return m_lpD3DDev->Clear(0, NULL, Flags, Color, Z, Stencil);
+}
+
+HRESULT CStateManager::SetViewport(const D3DVIEWPORT9* pViewport)
+{
+	return m_lpD3DDev->SetViewport(pViewport);
+}
+
+HRESULT CStateManager::GetViewport(D3DVIEWPORT9* pViewport)
+{
+	return m_lpD3DDev->GetViewport(pViewport);
+}
+
+void CStateManager::SaveViewport()
+{
+	m_lpD3DDev->GetViewport(&m_SavedViewport);
+}
+
+void CStateManager::RestoreViewport()
+{
+	m_lpD3DDev->SetViewport(&m_SavedViewport);
+}
+
 void CStateManager::GetLight(DWORD index, D3DLIGHT9* pLight)
 {
 	assert(index<8);

--- a/Lead-Client-Source/EterLib/StateManager.h
+++ b/Lead-Client-Source/EterLib/StateManager.h
@@ -256,6 +256,12 @@ class CStateManager : public CSingleton<CStateManager>
 		void	SetLight(DWORD index, CONST D3DLIGHT9* pLight);
 		void	GetLight(DWORD index, D3DLIGHT9* pLight);
 
+		HRESULT	Clear(DWORD Flags, D3DCOLOR Color, float Z, DWORD Stencil);
+		HRESULT	SetViewport(const D3DVIEWPORT9* pViewport);
+		HRESULT	GetViewport(D3DVIEWPORT9* pViewport);
+		void	SaveViewport();
+		void	RestoreViewport();
+
 		// Renderstates
 		void	SaveRenderState(D3DRENDERSTATETYPE Type, DWORD dwValue);
 		void	RestoreRenderState(D3DRENDERSTATETYPE Type);
@@ -354,6 +360,7 @@ class CStateManager : public CSingleton<CStateManager>
 		TStateID			m_DirtyStates;
 		bool				m_bForce;
 		bool				m_bScene;
+		D3DVIEWPORT9		m_SavedViewport;
 		DWORD				m_dwBestMinFilter;
 		DWORD				m_dwBestMagFilter;
 		LPDIRECT3DDEVICE9EX	m_lpD3DDev;

--- a/Lead-Client-Source/EterPythonLib/PythonGraphic.cpp
+++ b/Lead-Client-Source/EterPythonLib/PythonGraphic.cpp
@@ -96,7 +96,7 @@ void CPythonGraphic::SetOmniLight()
 
 void CPythonGraphic::SetViewport(float fx, float fy, float fWidth, float fHeight)
 {
-	ms_lpd3dDevice->GetViewport(&m_backupViewport);
+	STATEMANAGER.SaveViewport();
 
 	D3DVIEWPORT9 ViewPort;
 	ViewPort.X = static_cast<DWORD>(fx);
@@ -106,10 +106,10 @@ void CPythonGraphic::SetViewport(float fx, float fy, float fWidth, float fHeight
 	ViewPort.MinZ = 0.0f;
 	ViewPort.MaxZ = 1.0f;
 	if (FAILED(
-		ms_lpd3dDevice->SetViewport(&ViewPort)
+		STATEMANAGER.SetViewport(&ViewPort)
 	))
 	{
-		Tracef("CPythonGraphic::SetViewport(%d, %d, %d, %d) - Error", 
+		Tracef("CPythonGraphic::SetViewport(%d, %d, %d, %d) - Error",
 			ViewPort.X, ViewPort.Y,
 			ViewPort.Width, ViewPort.Height
 		);
@@ -118,7 +118,7 @@ void CPythonGraphic::SetViewport(float fx, float fy, float fWidth, float fHeight
 
 void CPythonGraphic::RestoreViewport()
 {
-	ms_lpd3dDevice->SetViewport(&m_backupViewport);
+	STATEMANAGER.RestoreViewport();
 }
 
 void CPythonGraphic::SetGamma(float fGammaFactor)
@@ -614,8 +614,6 @@ CPythonGraphic::CPythonGraphic()
 {
 	m_lightColor = GetColor(1.0f, 1.0f, 1.0f);
 	m_darkColor = GetColor(0.0f, 0.0f, 0.0f);
-	
-	memset(&m_backupViewport, 0, sizeof(D3DVIEWPORT9));
 
 	m_fOrthoDepth = 1000.0f;
 }

--- a/Lead-Client-Source/EterPythonLib/PythonGraphic.h
+++ b/Lead-Client-Source/EterPythonLib/PythonGraphic.h
@@ -62,7 +62,5 @@ class CPythonGraphic : public CScreen, public CSingleton<CPythonGraphic>
 
 		CCullingManager							m_CullingManager;
 
-		D3DVIEWPORT9							m_backupViewport;
-
 		float									m_fOrthoDepth;
 };

--- a/Lead-Client-Source/GameLib/MapOutdoorCharacterShadow.cpp
+++ b/Lead-Client-Source/GameLib/MapOutdoorCharacterShadow.cpp
@@ -116,19 +116,19 @@ bool CMapOutdoor::BeginRenderCharacterShadowToTexture()
 		bSuccess = false;
 	}
 
-	if (FAILED(ms_lpd3dDevice->Clear(0L, NULL, D3DCLEAR_TARGET | D3DCLEAR_ZBUFFER, D3DCOLOR_XRGB(0xFF, 0xFF, 0xFF), 1.0f, 0)))
+	if (FAILED(STATEMANAGER.Clear(D3DCLEAR_TARGET | D3DCLEAR_ZBUFFER, D3DCOLOR_XRGB(0xFF, 0xFF, 0xFF), 1.0f, 0)))
 	{
 		TraceError("CMapOutdoor::BeginRenderCharacterShadowToTexture : Unable to Clear Render Target");
 		bSuccess = false;
 	}
 
-	if (FAILED(ms_lpd3dDevice->GetViewport(&m_BackupViewport)))
+	if (FAILED(STATEMANAGER.GetViewport(&m_BackupViewport)))
 	{
 		TraceError("CMapOutdoor::BeginRenderCharacterShadowToTexture : Unable to Save Window Viewport\n");
 		bSuccess = false;
 	}
 
-	if (FAILED(ms_lpd3dDevice->SetViewport(&m_ShadowMapViewport)))
+	if (FAILED(STATEMANAGER.SetViewport(&m_ShadowMapViewport)))
 	{
 		TraceError("CMapOutdoor::BeginRenderCharacterShadowToTexture : Unable to Set Shadow Map viewport\n");
 		bSuccess = false;
@@ -139,7 +139,7 @@ bool CMapOutdoor::BeginRenderCharacterShadowToTexture()
 
 void CMapOutdoor::EndRenderCharacterShadowToTexture()
 {
-	ms_lpd3dDevice->SetViewport(&m_BackupViewport);
+	STATEMANAGER.SetViewport(&m_BackupViewport);
 
 	ms_lpd3dDevice->SetDepthStencilSurface(m_lpBackupDepthSurface);
 	ms_lpd3dDevice->SetRenderTarget(0, m_lpBackupRenderTargetSurface);

--- a/Lead-Client-Source/GameLib/SnowEnvironment.cpp
+++ b/Lead-Client-Source/GameLib/SnowEnvironment.cpp
@@ -94,7 +94,7 @@ void CSnowEnvironment::__BeginBlur()
 	ms_lpd3dDevice->GetDepthStencilSurface(&m_lpOldDepthStencilSurface);
 	ms_lpd3dDevice->SetDepthStencilSurface(m_lpSnowDepthSurface);
 	ms_lpd3dDevice->SetRenderTarget(0, m_lpSnowRenderTargetSurface);
-	ms_lpd3dDevice->Clear(0L, NULL, D3DCLEAR_TARGET|D3DCLEAR_ZBUFFER, 0x00000000, 1.0f, 0L);
+	STATEMANAGER.Clear(D3DCLEAR_TARGET|D3DCLEAR_ZBUFFER, 0x00000000, 1.0f, 0L);
 
 	STATEMANAGER.SetRenderState(D3DRS_ALPHABLENDENABLE, TRUE);
 	STATEMANAGER.SetRenderState(D3DRS_SRCBLEND, D3DBLEND_SRCALPHA);


### PR DESCRIPTION
Adds CStateManager::Clear plus SetViewport/GetViewport/SaveViewport/RestoreViewport (HRESULT pass-throughs so callers keep their FAILED() checks), and routes the Clear sites (GrpScreen, SnowEnvironment, character-shadow) and viewport sites (PythonGraphic, character-shadow) through them. PythonGraphic drops its m_backupViewport member in favor of Save/RestoreViewport.

Part of the DX9→DX12 migration (14). Independent. Debug|x64 builds 0/0.
