### PR TITLE
feat(client): add StateManager render-target/depth-surface wrappers

### DIFF
--- a/Lead-Client-Source/EterLib/StateManager.cpp
+++ b/Lead-Client-Source/EterLib/StateManager.cpp
@@ -23,6 +23,26 @@ void CStateManager::SetLight(DWORD index, CONST D3DLIGHT9* pLight)
 	m_lpD3DDev->SetLight(index, pLight);
 }
 
+HRESULT CStateManager::GetRenderTarget(DWORD RenderTargetIndex, LPDIRECT3DSURFACE9* ppRenderTarget)
+{
+	return m_lpD3DDev->GetRenderTarget(RenderTargetIndex, ppRenderTarget);
+}
+
+HRESULT CStateManager::SetRenderTarget(DWORD RenderTargetIndex, LPDIRECT3DSURFACE9 pRenderTarget)
+{
+	return m_lpD3DDev->SetRenderTarget(RenderTargetIndex, pRenderTarget);
+}
+
+HRESULT CStateManager::GetDepthStencilSurface(LPDIRECT3DSURFACE9* ppZStencilSurface)
+{
+	return m_lpD3DDev->GetDepthStencilSurface(ppZStencilSurface);
+}
+
+HRESULT CStateManager::SetDepthStencilSurface(LPDIRECT3DSURFACE9 pNewZStencil)
+{
+	return m_lpD3DDev->SetDepthStencilSurface(pNewZStencil);
+}
+
 void CStateManager::GetLight(DWORD index, D3DLIGHT9* pLight)
 {
 	assert(index<8);

--- a/Lead-Client-Source/EterLib/StateManager.h
+++ b/Lead-Client-Source/EterLib/StateManager.h
@@ -256,6 +256,11 @@ class CStateManager : public CSingleton<CStateManager>
 		void	SetLight(DWORD index, CONST D3DLIGHT9* pLight);
 		void	GetLight(DWORD index, D3DLIGHT9* pLight);
 
+		HRESULT	GetRenderTarget(DWORD RenderTargetIndex, LPDIRECT3DSURFACE9* ppRenderTarget);
+		HRESULT	SetRenderTarget(DWORD RenderTargetIndex, LPDIRECT3DSURFACE9 pRenderTarget);
+		HRESULT	GetDepthStencilSurface(LPDIRECT3DSURFACE9* ppZStencilSurface);
+		HRESULT	SetDepthStencilSurface(LPDIRECT3DSURFACE9 pNewZStencil);
+
 		// Renderstates
 		void	SaveRenderState(D3DRENDERSTATETYPE Type, DWORD dwValue);
 		void	RestoreRenderState(D3DRENDERSTATETYPE Type);

--- a/Lead-Client-Source/GameLib/MapOutdoorCharacterShadow.cpp
+++ b/Lead-Client-Source/GameLib/MapOutdoorCharacterShadow.cpp
@@ -92,25 +92,25 @@ bool CMapOutdoor::BeginRenderCharacterShadowToTexture()
 	bool bSuccess = true;
 
 	// Backup Device Context
-	if (FAILED(ms_lpd3dDevice->GetRenderTarget(0, &m_lpBackupRenderTargetSurface)))
+	if (FAILED(STATEMANAGER.GetRenderTarget(0, &m_lpBackupRenderTargetSurface)))
 	{
 		TraceError("CMapOutdoor::BeginRenderCharacterShadowToTexture : Unable to Save Window Render Target\n");
 		bSuccess = false;
 	}
 
-	if (FAILED(ms_lpd3dDevice->GetDepthStencilSurface(&m_lpBackupDepthSurface)))
+	if (FAILED(STATEMANAGER.GetDepthStencilSurface(&m_lpBackupDepthSurface)))
 	{
 		TraceError("CMapOutdoor::BeginRenderCharacterShadowToTexture : Unable to Save Window Depth Surface\n");
 		bSuccess = false;
 	}
 
-	if (FAILED(ms_lpd3dDevice->SetRenderTarget(0, m_lpCharacterShadowMapRenderTargetSurface)))
+	if (FAILED(STATEMANAGER.SetRenderTarget(0, m_lpCharacterShadowMapRenderTargetSurface)))
 	{
 		TraceError("CMapOutdoor::BeginRenderCharacterShadowToTexture : Unable to Set Shadow Map Render Target\n");
 		bSuccess = false;
 	}
 
-	if (FAILED(ms_lpd3dDevice->SetDepthStencilSurface(m_lpCharacterShadowMapDepthSurface)))
+	if (FAILED(STATEMANAGER.SetDepthStencilSurface(m_lpCharacterShadowMapDepthSurface)))
 	{
 		TraceError("CMapOutdoor::BeginRenderCharacterShadowToTexture : Unable to Set Shadow Map Render Target\n");
 		bSuccess = false;
@@ -141,8 +141,8 @@ void CMapOutdoor::EndRenderCharacterShadowToTexture()
 {
 	ms_lpd3dDevice->SetViewport(&m_BackupViewport);
 
-	ms_lpd3dDevice->SetDepthStencilSurface(m_lpBackupDepthSurface);
-	ms_lpd3dDevice->SetRenderTarget(0, m_lpBackupRenderTargetSurface);
+	STATEMANAGER.SetDepthStencilSurface(m_lpBackupDepthSurface);
+	STATEMANAGER.SetRenderTarget(0, m_lpBackupRenderTargetSurface);
 
 	SAFE_RELEASE(m_lpBackupDepthSurface);
 	SAFE_RELEASE(m_lpBackupRenderTargetSurface);

--- a/Lead-Client-Source/GameLib/SnowEnvironment.cpp
+++ b/Lead-Client-Source/GameLib/SnowEnvironment.cpp
@@ -90,10 +90,10 @@ void CSnowEnvironment::__BeginBlur()
 	if (!m_bBlurEnable)
 		return;
 
-	ms_lpd3dDevice->GetRenderTarget(0, &m_lpOldSurface);
-	ms_lpd3dDevice->GetDepthStencilSurface(&m_lpOldDepthStencilSurface);
-	ms_lpd3dDevice->SetDepthStencilSurface(m_lpSnowDepthSurface);
-	ms_lpd3dDevice->SetRenderTarget(0, m_lpSnowRenderTargetSurface);
+	STATEMANAGER.GetRenderTarget(0, &m_lpOldSurface);
+	STATEMANAGER.GetDepthStencilSurface(&m_lpOldDepthStencilSurface);
+	STATEMANAGER.SetDepthStencilSurface(m_lpSnowDepthSurface);
+	STATEMANAGER.SetRenderTarget(0, m_lpSnowRenderTargetSurface);
 	ms_lpd3dDevice->Clear(0L, NULL, D3DCLEAR_TARGET|D3DCLEAR_ZBUFFER, 0x00000000, 1.0f, 0L);
 
 	STATEMANAGER.SetRenderState(D3DRS_ALPHABLENDENABLE, TRUE);
@@ -145,8 +145,8 @@ void CSnowEnvironment::__ApplyBlur()
 
 	///////////////
 	{
-		ms_lpd3dDevice->SetDepthStencilSurface(m_lpOldDepthStencilSurface);
-		ms_lpd3dDevice->SetRenderTarget(0, m_lpOldSurface);
+		STATEMANAGER.SetDepthStencilSurface(m_lpOldDepthStencilSurface);
+		STATEMANAGER.SetRenderTarget(0, m_lpOldSurface);
 
 		STATEMANAGER.SetTexture(0,m_lpSnowTexture);
 		STATEMANAGER.SetRenderState( D3DRS_ALPHABLENDENABLE,   TRUE);


### PR DESCRIPTION
Adds CStateManager Get/SetRenderTarget and Get/SetDepthStencilSurface (HRESULT pass-throughs, preserving the device's AddRef-on-Get semantics), and routes the two render-to-texture passes (character shadow map, snow blur) through them. Callers keep their backup surface members and Release calls unchanged; pure funneling with no ownership change.

Part of the DX9→DX12 migration (15). Independent. Debug|x64 builds 0/0.
