### PR TITLE
refactor(client): create EterLib textures and buffers via the factory

### DIFF
--- a/Lead-Client-Source/EterLib/BlockTexture.cpp
+++ b/Lead-Client-Source/EterLib/BlockTexture.cpp
@@ -155,7 +155,7 @@ void CBlockTexture::InvalidateRect(const RECT & c_rsrcRect)
 
 bool CBlockTexture::Create(CGraphicDib * pDIB, const RECT & c_rRect, DWORD dwWidth, DWORD dwHeight)
 {	
-	if (FAILED(ms_lpd3dDevice->CreateTexture(dwWidth, dwHeight, 0, D3DUSAGE_DYNAMIC, D3DFMT_A8R8G8B8, D3DPOOL_DEFAULT, &m_lpd3dTexture, NULL)))
+	if (FAILED(CreateDeviceTexture(dwWidth, dwHeight, 0, D3DUSAGE_DYNAMIC, D3DFMT_A8R8G8B8, D3DPOOL_DEFAULT, &m_lpd3dTexture)))
 	{
 		Tracef("Failed to create block texture %u, %u\n", dwWidth, dwHeight);
 		return false;

--- a/Lead-Client-Source/EterLib/EterLib.vcxproj
+++ b/Lead-Client-Source/EterLib/EterLib.vcxproj
@@ -176,6 +176,7 @@
     <ClCompile Include="GrpVertexBufferStatic.cpp" />
     <ClCompile Include="GrpVertexShader.cpp" />
     <ClCompile Include="IME.cpp" />
+    <ClCompile Include="ImageFileDecoder.cpp" />
     <ClCompile Include="Input.cpp" />
     <ClCompile Include="JpegFile.cpp" />
     <ClCompile Include="LensFlare.cpp" />
@@ -253,6 +254,7 @@
     <ClInclude Include="GrpVertexBufferStatic.h" />
     <ClInclude Include="GrpVertexShader.h" />
     <ClInclude Include="IME.h" />
+    <ClInclude Include="ImageFileDecoder.h" />
     <ClInclude Include="Input.h" />
     <ClInclude Include="JpegFile.h" />
     <ClInclude Include="LensFlare.h" />

--- a/Lead-Client-Source/EterLib/EterLib.vcxproj.filters
+++ b/Lead-Client-Source/EterLib/EterLib.vcxproj.filters
@@ -25,6 +25,7 @@
     <ClCompile Include="GrpImage.cpp" />
     <ClCompile Include="GrpImageInstance.cpp" />
     <ClCompile Include="GrpImageTexture.cpp" />
+    <ClCompile Include="ImageFileDecoder.cpp" />
     <ClCompile Include="GrpIndexBuffer.cpp" />
     <ClCompile Include="GrpLightManager.cpp" />
     <ClCompile Include="GrpMarkInstance.cpp" />
@@ -99,6 +100,7 @@
     <ClInclude Include="GrpImage.h" />
     <ClInclude Include="GrpImageInstance.h" />
     <ClInclude Include="GrpImageTexture.h" />
+    <ClInclude Include="ImageFileDecoder.h" />
     <ClInclude Include="GrpIndexBuffer.h" />
     <ClInclude Include="GrpLightManager.h" />
     <ClInclude Include="GrpMarkInstance.h" />

--- a/Lead-Client-Source/EterLib/GrpBase.cpp
+++ b/Lead-Client-Source/EterLib/GrpBase.cpp
@@ -239,7 +239,7 @@ void CGraphicBase::SetSimpleCamera(float x, float y, float z, float pitch, float
 	UpdateViewMatrix();
 
 	// This is levites's virtual(?) code which you should not trust.
-	ms_lpd3dDevice->GetTransform(D3DTS_WORLD, &ms_matWorld);
+	STATEMANAGER.GetTransform(D3DTS_WORLD, &ms_matWorld);
 	D3DXMatrixMultiply(&ms_matWorldView, &ms_matWorld, &ms_matView);
 }
 
@@ -256,7 +256,7 @@ void CGraphicBase::SetAroundCamera(float distance, float pitch, float roll, floa
 	UpdateViewMatrix();
 
 	// This is levites's virtual(?) code which you should not trust.
-	ms_lpd3dDevice->GetTransform(D3DTS_WORLD, &ms_matWorld);
+	STATEMANAGER.GetTransform(D3DTS_WORLD, &ms_matWorld);
 	D3DXMatrixMultiply(&ms_matWorldView, &ms_matWorld, &ms_matView);
 }
 
@@ -504,6 +504,31 @@ void CGraphicBase::ResetFaceCount()
 HRESULT CGraphicBase::GetLastResult()
 {
 	return ms_hLastResult;
+}
+
+HRESULT CGraphicBase::CreateDeviceTexture(UINT uWidth, UINT uHeight, UINT uLevels, DWORD dwUsage, D3DFORMAT eFormat, D3DPOOL ePool, LPDIRECT3DTEXTURE9* ppTexture)
+{
+	return ms_lpd3dDevice->CreateTexture(uWidth, uHeight, uLevels, dwUsage, eFormat, ePool, ppTexture, NULL);
+}
+
+HRESULT CGraphicBase::CreateDeviceVertexBuffer(UINT uLength, DWORD dwUsage, DWORD dwFVF, D3DPOOL ePool, LPDIRECT3DVERTEXBUFFER9* ppVertexBuffer)
+{
+	return ms_lpd3dDevice->CreateVertexBuffer(uLength, dwUsage, dwFVF, ePool, ppVertexBuffer, NULL);
+}
+
+HRESULT CGraphicBase::CreateDeviceIndexBuffer(UINT uLength, DWORD dwUsage, D3DFORMAT eFormat, D3DPOOL ePool, LPDIRECT3DINDEXBUFFER9* ppIndexBuffer)
+{
+	return ms_lpd3dDevice->CreateIndexBuffer(uLength, dwUsage, eFormat, ePool, ppIndexBuffer, NULL);
+}
+
+HRESULT CGraphicBase::CreateDeviceDepthStencilSurface(UINT uWidth, UINT uHeight, D3DFORMAT eFormat, D3DMULTISAMPLE_TYPE eMultiSample, DWORD dwMultisampleQuality, BOOL bDiscard, LPDIRECT3DSURFACE9* ppSurface)
+{
+	return ms_lpd3dDevice->CreateDepthStencilSurface(uWidth, uHeight, eFormat, eMultiSample, dwMultisampleQuality, bDiscard, ppSurface, NULL);
+}
+
+HRESULT CGraphicBase::UpdateDeviceTexture(LPDIRECT3DBASETEXTURE9 pSourceTexture, LPDIRECT3DBASETEXTURE9 pDestinationTexture)
+{
+	return ms_lpd3dDevice->UpdateTexture(pSourceTexture, pDestinationTexture);
 }
 
 CGraphicBase::CGraphicBase()

--- a/Lead-Client-Source/EterLib/GrpBase.h
+++ b/Lead-Client-Source/EterLib/GrpBase.h
@@ -216,6 +216,14 @@ class CGraphicBase
 		static void SetDefaultIndexBuffer(UINT eDefIB);
 		static bool SetPDTStream(SPDTVertexRaw* pVertices, UINT uVtxCount);
 		static bool SetPDTStream(SPDTVertex* pVertices, UINT uVtxCount);
+
+		// Resource-creation seam: every device object the renderer allocates
+		// goes through these, so a future backend can swap allocation in one place.
+		static HRESULT CreateDeviceTexture(UINT uWidth, UINT uHeight, UINT uLevels, DWORD dwUsage, D3DFORMAT eFormat, D3DPOOL ePool, LPDIRECT3DTEXTURE9* ppTexture);
+		static HRESULT CreateDeviceVertexBuffer(UINT uLength, DWORD dwUsage, DWORD dwFVF, D3DPOOL ePool, LPDIRECT3DVERTEXBUFFER9* ppVertexBuffer);
+		static HRESULT CreateDeviceIndexBuffer(UINT uLength, DWORD dwUsage, D3DFORMAT eFormat, D3DPOOL ePool, LPDIRECT3DINDEXBUFFER9* ppIndexBuffer);
+		static HRESULT CreateDeviceDepthStencilSurface(UINT uWidth, UINT uHeight, D3DFORMAT eFormat, D3DMULTISAMPLE_TYPE eMultiSample, DWORD dwMultisampleQuality, BOOL bDiscard, LPDIRECT3DSURFACE9* ppSurface);
+		static HRESULT UpdateDeviceTexture(LPDIRECT3DBASETEXTURE9 pSourceTexture, LPDIRECT3DBASETEXTURE9 pDestinationTexture);
 		
 	protected:
 		static D3DXMATRIX				ms_matIdentity;

--- a/Lead-Client-Source/EterLib/GrpImageTexture.cpp
+++ b/Lead-Client-Source/EterLib/GrpImageTexture.cpp
@@ -2,6 +2,131 @@
 #include "../eterBase/MappedFile.h"
 #include "../eterPack/EterPackManager.h"
 #include "GrpImageTexture.h"
+#include "ImageFileDecoder.h"
+
+namespace
+{
+	// D3DX-style colorkey: pixels matching the ARGB key become transparent black.
+	void ApplyColorKey(SDecodedImage& rkImage, DWORD dwARGBColorKey)
+	{
+		const BYTE byA = BYTE(dwARGBColorKey >> 24);
+		const BYTE byR = BYTE(dwARGBColorKey >> 16);
+		const BYTE byG = BYTE(dwARGBColorKey >> 8);
+		const BYTE byB = BYTE(dwARGBColorKey);
+
+		BYTE* pbyPixel = rkImage.kPixels.data();
+		BYTE* pbyEnd = pbyPixel + rkImage.kPixels.size();
+		for (; pbyPixel < pbyEnd; pbyPixel += 4)
+		{
+			if (pbyPixel[0] == byB && pbyPixel[1] == byG && pbyPixel[2] == byR && pbyPixel[3] == byA)
+			{
+				pbyPixel[0] = 0;
+				pbyPixel[1] = 0;
+				pbyPixel[2] = 0;
+				pbyPixel[3] = 0;
+			}
+		}
+	}
+
+	// 2x2 box filter (clamped at odd edges) - equivalent of D3DX_FILTER_LINEAR mips.
+	void DownsampleBox(const std::vector<BYTE>& c_rkSrc, UINT uSrcWidth, UINT uSrcHeight,
+					   std::vector<BYTE>& rkDst, UINT uDstWidth, UINT uDstHeight)
+	{
+		rkDst.resize(size_t(uDstWidth) * uDstHeight * 4);
+
+		for (UINT y = 0; y < uDstHeight; ++y)
+		{
+			const UINT uSrcY0 = y * 2;
+			const UINT uSrcY1 = (uSrcY0 + 1 < uSrcHeight) ? uSrcY0 + 1 : uSrcY0;
+			for (UINT x = 0; x < uDstWidth; ++x)
+			{
+				const UINT uSrcX0 = x * 2;
+				const UINT uSrcX1 = (uSrcX0 + 1 < uSrcWidth) ? uSrcX0 + 1 : uSrcX0;
+
+				const BYTE* pbySrc00 = &c_rkSrc[(size_t(uSrcY0) * uSrcWidth + uSrcX0) * 4];
+				const BYTE* pbySrc01 = &c_rkSrc[(size_t(uSrcY0) * uSrcWidth + uSrcX1) * 4];
+				const BYTE* pbySrc10 = &c_rkSrc[(size_t(uSrcY1) * uSrcWidth + uSrcX0) * 4];
+				const BYTE* pbySrc11 = &c_rkSrc[(size_t(uSrcY1) * uSrcWidth + uSrcX1) * 4];
+
+				BYTE* pbyDst = &rkDst[(size_t(y) * uDstWidth + x) * 4];
+				for (UINT c = 0; c < 4; ++c)
+					pbyDst[c] = BYTE((UINT(pbySrc00[c]) + pbySrc01[c] + pbySrc10[c] + pbySrc11[c] + 2) / 4);
+			}
+		}
+	}
+
+	// Full-mip-chain A8R8G8B8 texture from decoded pixels (staging -> default, like the DDS path).
+	LPDIRECT3DTEXTURE9 CreateTextureFromDecodedImage(LPDIRECT3DDEVICE9 lpDevice, const SDecodedImage& c_rkImage)
+	{
+		UINT uMipCount = 1;
+		{
+			UINT uWidth = c_rkImage.uWidth;
+			UINT uHeight = c_rkImage.uHeight;
+			while (uWidth > 1 || uHeight > 1)
+			{
+				uWidth = uWidth > 1 ? uWidth / 2 : 1;
+				uHeight = uHeight > 1 ? uHeight / 2 : 1;
+				++uMipCount;
+			}
+		}
+
+		LPDIRECT3DTEXTURE9 lpd3dStaging = NULL;
+		LPDIRECT3DTEXTURE9 lpd3dTexture = NULL;
+
+		if (FAILED(lpDevice->CreateTexture(c_rkImage.uWidth, c_rkImage.uHeight,
+										   uMipCount, 0, D3DFMT_A8R8G8B8, D3DPOOL_SYSTEMMEM, &lpd3dStaging, NULL)))
+			return NULL;
+
+		if (FAILED(lpDevice->CreateTexture(c_rkImage.uWidth, c_rkImage.uHeight,
+										   uMipCount, 0, D3DFMT_A8R8G8B8, D3DPOOL_DEFAULT, &lpd3dTexture, NULL)))
+		{
+			lpd3dStaging->Release();
+			return NULL;
+		}
+
+		std::vector<BYTE> kLevelPixels = c_rkImage.kPixels;
+		std::vector<BYTE> kNextPixels;
+		UINT uLevelWidth = c_rkImage.uWidth;
+		UINT uLevelHeight = c_rkImage.uHeight;
+
+		for (UINT uLevel = 0; uLevel < uMipCount; ++uLevel)
+		{
+			D3DLOCKED_RECT lockedRect;
+			if (SUCCEEDED(lpd3dStaging->LockRect(uLevel, &lockedRect, NULL, 0)))
+			{
+				const BYTE* pbySrcRow = kLevelPixels.data();
+				BYTE* pbyDstRow = (BYTE*)lockedRect.pBits;
+				for (UINT y = 0; y < uLevelHeight; ++y)
+				{
+					memcpy(pbyDstRow, pbySrcRow, size_t(uLevelWidth) * 4);
+					pbySrcRow += size_t(uLevelWidth) * 4;
+					pbyDstRow += lockedRect.Pitch;
+				}
+				lpd3dStaging->UnlockRect(uLevel);
+			}
+
+			if (uLevel + 1 < uMipCount)
+			{
+				const UINT uNextWidth = uLevelWidth > 1 ? uLevelWidth / 2 : 1;
+				const UINT uNextHeight = uLevelHeight > 1 ? uLevelHeight / 2 : 1;
+				DownsampleBox(kLevelPixels, uLevelWidth, uLevelHeight, kNextPixels, uNextWidth, uNextHeight);
+				kLevelPixels.swap(kNextPixels);
+				uLevelWidth = uNextWidth;
+				uLevelHeight = uNextHeight;
+			}
+		}
+
+		if (FAILED(lpDevice->UpdateTexture(lpd3dStaging, lpd3dTexture)))
+		{
+			lpd3dStaging->Release();
+			lpd3dTexture->Release();
+			return NULL;
+		}
+
+		lpd3dStaging->Release();
+		return lpd3dTexture;
+	}
+}
 
 bool CGraphicImageTexture::Lock(int* pRetPitch, void** ppRetPixels, int level)
 {
@@ -186,30 +311,30 @@ bool CGraphicImageTexture::CreateFromMemoryFile(UINT bufSize, const void * c_pvB
 	}
 	else
 	{
-		D3DXIMAGE_INFO imageInfo;
-		if (FAILED(D3DXCreateTextureFromFileInMemoryEx(
-					ms_lpd3dDevice,
-					c_pvBuf,
-					bufSize,
-						D3DX_DEFAULT_NONPOW2,
-						D3DX_DEFAULT_NONPOW2,
-					D3DX_DEFAULT,
-					0,
-					d3dFmt,
-						D3DPOOL_DEFAULT,
-					dwFilter,
-					dwFilter,
-					0xffff00ff,
-					&imageInfo,
-					NULL,
-					&m_lpd3dTexture)))
+		if (D3DFMT_UNKNOWN != d3dFmt && D3DFMT_A8R8G8B8 != d3dFmt)
+		{
+			TraceError("CreateFromMemoryFile: Unsupported format request %u", d3dFmt);
+			return false;
+		}
+
+		SDecodedImage kImage;
+		if (!DecodeImageFileFromMemory(c_pvBuf, bufSize, &kImage))
 		{
 			TraceError("CreateFromMemoryFile: Cannot create texture");
 			return false;
 		}
 
-		m_width = imageInfo.Width;
-		m_height = imageInfo.Height;
+		ApplyColorKey(kImage, 0xffff00ff);
+
+		m_lpd3dTexture = CreateTextureFromDecodedImage(ms_lpd3dDevice, kImage);
+		if (!m_lpd3dTexture)
+		{
+			TraceError("CreateFromMemoryFile: Cannot create texture");
+			return false;
+		}
+
+		m_width = kImage.uWidth;
+		m_height = kImage.uHeight;
 	}
 
 	m_bEmpty = false;

--- a/Lead-Client-Source/EterLib/GrpImageTexture.cpp
+++ b/Lead-Client-Source/EterLib/GrpImageTexture.cpp
@@ -56,7 +56,7 @@ namespace
 	}
 
 	// Full-mip-chain A8R8G8B8 texture from decoded pixels (staging -> default, like the DDS path).
-	LPDIRECT3DTEXTURE9 CreateTextureFromDecodedImage(LPDIRECT3DDEVICE9 lpDevice, const SDecodedImage& c_rkImage)
+	LPDIRECT3DTEXTURE9 CreateTextureFromDecodedImage(const SDecodedImage& c_rkImage)
 	{
 		UINT uMipCount = 1;
 		{
@@ -73,12 +73,12 @@ namespace
 		LPDIRECT3DTEXTURE9 lpd3dStaging = NULL;
 		LPDIRECT3DTEXTURE9 lpd3dTexture = NULL;
 
-		if (FAILED(lpDevice->CreateTexture(c_rkImage.uWidth, c_rkImage.uHeight,
-										   uMipCount, 0, D3DFMT_A8R8G8B8, D3DPOOL_SYSTEMMEM, &lpd3dStaging, NULL)))
+		if (FAILED(CGraphicBase::CreateDeviceTexture(c_rkImage.uWidth, c_rkImage.uHeight,
+										   uMipCount, 0, D3DFMT_A8R8G8B8, D3DPOOL_SYSTEMMEM, &lpd3dStaging)))
 			return NULL;
 
-		if (FAILED(lpDevice->CreateTexture(c_rkImage.uWidth, c_rkImage.uHeight,
-										   uMipCount, 0, D3DFMT_A8R8G8B8, D3DPOOL_DEFAULT, &lpd3dTexture, NULL)))
+		if (FAILED(CGraphicBase::CreateDeviceTexture(c_rkImage.uWidth, c_rkImage.uHeight,
+										   uMipCount, 0, D3DFMT_A8R8G8B8, D3DPOOL_DEFAULT, &lpd3dTexture)))
 		{
 			lpd3dStaging->Release();
 			return NULL;
@@ -116,7 +116,7 @@ namespace
 			}
 		}
 
-		if (FAILED(lpDevice->UpdateTexture(lpd3dStaging, lpd3dTexture)))
+		if (FAILED(CGraphicBase::UpdateDeviceTexture(lpd3dStaging, lpd3dTexture)))
 		{
 			lpd3dStaging->Release();
 			lpd3dTexture->Release();
@@ -177,7 +177,7 @@ bool CGraphicImageTexture::CreateDeviceObjects()
 
 	if (m_stFileName.empty())
 	{
-		if (FAILED(ms_lpd3dDevice->CreateTexture(m_width, m_height, 1, D3DUSAGE_DYNAMIC, m_d3dFmt, D3DPOOL_DEFAULT, &m_lpd3dTexture, NULL)))
+		if (FAILED(CreateDeviceTexture(m_width, m_height, 1, D3DUSAGE_DYNAMIC, m_d3dFmt, D3DPOOL_DEFAULT, &m_lpd3dTexture)))
 			return false;
 	}
 	else
@@ -244,15 +244,15 @@ bool CGraphicImageTexture::CreateDDSTexture(CDXTCImage & image, const BYTE * /*c
 	else
 		format = D3DFMT_DXT1;
 
-	if (FAILED(ms_lpd3dDevice->CreateTexture(	image.m_nWidth, image.m_nHeight,
-										mipmapCount, 0, format, D3DPOOL_SYSTEMMEM, &lpd3dStaging, NULL)))
+	if (FAILED(CreateDeviceTexture(	image.m_nWidth, image.m_nHeight,
+										mipmapCount, 0, format, D3DPOOL_SYSTEMMEM, &lpd3dStaging)))
 	{
 		TraceError("CreateDDSTexture: Cannot creatre texture" );
 		return false;
 	}
 
-	if (FAILED(ms_lpd3dDevice->CreateTexture(	image.m_nWidth, image.m_nHeight,
-									mipmapCount, 0, format, D3DPOOL_DEFAULT, &lpd3dTexture, NULL)))
+	if (FAILED(CreateDeviceTexture(	image.m_nWidth, image.m_nHeight,
+									mipmapCount, 0, format, D3DPOOL_DEFAULT, &lpd3dTexture)))
 	{
 		TraceError("CreateDDSTexture: Cannot creatre texture");
 		lpd3dStaging->Release();
@@ -278,7 +278,7 @@ bool CGraphicImageTexture::CreateDDSTexture(CDXTCImage & image, const BYTE * /*c
 		}
 	}
 
-	HRESULT hrUpdate = ms_lpd3dDevice->UpdateTexture(lpd3dStaging, lpd3dTexture);
+	HRESULT hrUpdate = UpdateDeviceTexture(lpd3dStaging, lpd3dTexture);
 	if (FAILED(hrUpdate))
 	{
 		TraceError("CreateDDSTexture: UpdateTexture failed hr=0x%08X", hrUpdate);
@@ -326,7 +326,7 @@ bool CGraphicImageTexture::CreateFromMemoryFile(UINT bufSize, const void * c_pvB
 
 		ApplyColorKey(kImage, 0xffff00ff);
 
-		m_lpd3dTexture = CreateTextureFromDecodedImage(ms_lpd3dDevice, kImage);
+		m_lpd3dTexture = CreateTextureFromDecodedImage(kImage);
 		if (!m_lpd3dTexture)
 		{
 			TraceError("CreateFromMemoryFile: Cannot create texture");

--- a/Lead-Client-Source/EterLib/GrpImageTexture.cpp
+++ b/Lead-Client-Source/EterLib/GrpImageTexture.cpp
@@ -111,40 +111,23 @@ bool CGraphicImageTexture::CreateDDSTexture(CDXTCImage & image, const BYTE * /*c
 	D3DFORMAT format;
 	LPDIRECT3DTEXTURE9 lpd3dTexture = NULL;
 	LPDIRECT3DTEXTURE9 lpd3dStaging = NULL;
-	D3DPOOL pool = D3DPOOL_DEFAULT;
 
 	if(image.m_CompFormat == PF_DXT5)
-		format = D3DFMT_DXT5;	
+		format = D3DFMT_DXT5;
 	else if(image.m_CompFormat == PF_DXT3)
-		format = D3DFMT_DXT3;	
+		format = D3DFMT_DXT3;
 	else
-		format = D3DFMT_DXT1;	
+		format = D3DFMT_DXT1;
 
-	UINT uTexBias=0;
-	if (IsLowTextureMemory())
-		uTexBias=1;
-
-	UINT uMinMipMapIndex=0;
-	if (uTexBias>0)
-	{
-		if (mipmapCount>uTexBias)
-		{
-			uMinMipMapIndex=uTexBias;
-			image.m_nWidth>>=uTexBias;
-			image.m_nHeight>>=uTexBias;
-			mipmapCount-=uTexBias;
-		}
-	}
-
-	if (FAILED(D3DXCreateTexture(	ms_lpd3dDevice, image.m_nWidth, image.m_nHeight,
-										mipmapCount, 0, format, D3DPOOL_SYSTEMMEM, &lpd3dStaging)))
+	if (FAILED(ms_lpd3dDevice->CreateTexture(	image.m_nWidth, image.m_nHeight,
+										mipmapCount, 0, format, D3DPOOL_SYSTEMMEM, &lpd3dStaging, NULL)))
 	{
 		TraceError("CreateDDSTexture: Cannot creatre texture" );
 		return false;
 	}
 
-	if (FAILED(D3DXCreateTexture(	ms_lpd3dDevice, image.m_nWidth, image.m_nHeight,
-									mipmapCount, 0, format, pool, &lpd3dTexture)))
+	if (FAILED(ms_lpd3dDevice->CreateTexture(	image.m_nWidth, image.m_nHeight,
+									mipmapCount, 0, format, D3DPOOL_DEFAULT, &lpd3dTexture, NULL)))
 	{
 		TraceError("CreateDDSTexture: Cannot creatre texture");
 		lpd3dStaging->Release();
@@ -165,7 +148,7 @@ bool CGraphicImageTexture::CreateDDSTexture(CDXTCImage & image, const BYTE * /*c
 		}
 		else
 		{
-			image.Copy(i+uMinMipMapIndex, (BYTE*)lockedRect.pBits, lockedRect.Pitch);
+			image.Copy(i, (BYTE*)lockedRect.pBits, lockedRect.Pitch);
 			lpd3dStaging->UnlockRect(i);
 		}
 	}
@@ -181,56 +164,7 @@ bool CGraphicImageTexture::CreateDDSTexture(CDXTCImage & image, const BYTE * /*c
 
 	lpd3dStaging->Release();
 
-	if(ms_bSupportDXT)
-	{
-		m_lpd3dTexture = lpd3dTexture;
-	}
-	else
-	{
-		if(image.m_CompFormat == PF_DXT3 || image.m_CompFormat == PF_DXT5)
-			format = D3DFMT_A4R4G4B4;
-		else
-			format = D3DFMT_A1R5G5B5;
-
-		UINT imgWidth=image.m_nWidth;
-		UINT imgHeight=image.m_nHeight;
-
-		extern bool GRAPHICS_CAPS_HALF_SIZE_IMAGE;
-
-		if (GRAPHICS_CAPS_HALF_SIZE_IMAGE && uTexBias>0 && mipmapCount==0)
-		{
-			imgWidth>>=uTexBias;
-			imgHeight>>=uTexBias;		
-		}
-
-		if (FAILED(D3DXCreateTexture(	ms_lpd3dDevice, imgWidth, imgHeight, 
-									mipmapCount, 0, format, D3DPOOL_DEFAULT, &m_lpd3dTexture)))
-		{
-				TraceError("CreateDDSTexture: Cannot creatre texture");
-				return false;
-		}
-
-		IDirect3DTexture9* pkTexSrc=lpd3dTexture;
-		IDirect3DTexture9* pkTexDst=m_lpd3dTexture;
-
-		for(int i=0; i<mipmapCount; ++i) {
-
-			IDirect3DSurface9* ppsSrc = NULL;
-			IDirect3DSurface9* ppsDst = NULL;
-
-			if (SUCCEEDED(pkTexSrc->GetSurfaceLevel(i, &ppsSrc)))
-			{
-				if (SUCCEEDED(pkTexDst->GetSurfaceLevel(i, &ppsDst)))
-				{
-					D3DXLoadSurfaceFromSurface(ppsDst, NULL, NULL, ppsSrc, NULL, NULL, D3DX_FILTER_NONE, 0);
-					ppsDst->Release();
-				}
-				ppsSrc->Release();
-			}
-		}
-
-		lpd3dTexture->Release();
-	}
+	m_lpd3dTexture = lpd3dTexture;
 
 	m_width = image.m_nWidth;
 	m_height = image.m_nHeight;
@@ -276,63 +210,6 @@ bool CGraphicImageTexture::CreateFromMemoryFile(UINT bufSize, const void * c_pvB
 
 		m_width = imageInfo.Width;
 		m_height = imageInfo.Height;
-
-		D3DFORMAT format=imageInfo.Format;
-		switch(imageInfo.Format) {
-			case D3DFMT_A8R8G8B8:
-				format = D3DFMT_A4R4G4B4;
-				break;
-
-			case D3DFMT_X8R8G8B8:
-			case D3DFMT_R8G8B8:
-				format = D3DFMT_A1R5G5B5;
-				break;
-		}
-
-		UINT uTexBias=0;
-
-		extern bool GRAPHICS_CAPS_HALF_SIZE_IMAGE;
-		if (GRAPHICS_CAPS_HALF_SIZE_IMAGE)
-			uTexBias=1;
-
-		if (IsLowTextureMemory())
-		if (uTexBias || format!=imageInfo.Format)
-		{
-			IDirect3DTexture9* pkTexSrc=m_lpd3dTexture;
-			IDirect3DTexture9* pkTexDst;
-			
-			
-			if (SUCCEEDED(D3DXCreateTexture(	
-				ms_lpd3dDevice, 
-				imageInfo.Width>>uTexBias, 
-				imageInfo.Height>>uTexBias, 
-				imageInfo.MipLevels, 
-				0, 
-				format, 
-				D3DPOOL_DEFAULT,
-				&pkTexDst)))
-			{
-				m_lpd3dTexture=pkTexDst;
-				
-				for(int i=0; i<imageInfo.MipLevels; ++i) {
-
-					IDirect3DSurface9* ppsSrc = NULL;
-					IDirect3DSurface9* ppsDst = NULL;
-
-					if (SUCCEEDED(pkTexSrc->GetSurfaceLevel(i, &ppsSrc)))
-					{
-						if (SUCCEEDED(pkTexDst->GetSurfaceLevel(i, &ppsDst)))
-						{
-							D3DXLoadSurfaceFromSurface(ppsDst, NULL, NULL, ppsSrc, NULL, NULL, D3DX_FILTER_LINEAR, 0);
-							ppsDst->Release();
-						}
-						ppsSrc->Release();
-					}
-				}
-
-				pkTexSrc->Release();
-			}
-		}
 	}
 
 	m_bEmpty = false;

--- a/Lead-Client-Source/EterLib/GrpIndexBuffer.cpp
+++ b/Lead-Client-Source/EterLib/GrpIndexBuffer.cpp
@@ -106,13 +106,12 @@ bool CGraphicIndexBuffer::Create(int faceCount, TFace* faces)
 
 bool CGraphicIndexBuffer::CreateDeviceObjects()
 {
-	if (FAILED(ms_lpd3dDevice->CreateIndexBuffer(
-			m_dwBufferSize, 
-			D3DUSAGE_WRITEONLY, 
+	if (FAILED(CreateDeviceIndexBuffer(
+			m_dwBufferSize,
+			D3DUSAGE_WRITEONLY,
 			m_d3dFmt,
-			D3DPOOL_DEFAULT, 
-			&m_lpd3dIdxBuf,
-			NULL)
+			D3DPOOL_DEFAULT,
+			&m_lpd3dIdxBuf)
 			))
 			return false;
 

--- a/Lead-Client-Source/EterLib/GrpVertexBuffer.cpp
+++ b/Lead-Client-Source/EterLib/GrpVertexBuffer.cpp
@@ -134,13 +134,12 @@ bool CGraphicVertexBuffer::CreateDeviceObjects()
 	assert(m_lpd3dVB == NULL);
 
 	if (FAILED(
-		ms_lpd3dDevice->CreateVertexBuffer(
-		m_dwBufferSize, 
-		m_dwUsage, 
-		m_dwFVF, 
-		m_d3dPool, 
-		&m_lpd3dVB,
-		NULL)
+		CreateDeviceVertexBuffer(
+		m_dwBufferSize,
+		m_dwUsage,
+		m_dwFVF,
+		m_d3dPool,
+		&m_lpd3dVB)
 		))
 		return false;
 

--- a/Lead-Client-Source/EterLib/ImageFileDecoder.cpp
+++ b/Lead-Client-Source/EterLib/ImageFileDecoder.cpp
@@ -1,0 +1,371 @@
+#include "StdAfx.h"
+#include "ImageFileDecoder.h"
+
+#include <wincodec.h>
+
+#pragma comment(lib, "windowscodecs.lib")
+#pragma comment(lib, "ole32.lib")
+
+namespace
+{
+#pragma pack(push, 1)
+	struct SDDSPixelFormat
+	{
+		DWORD dwSize;
+		DWORD dwFlags;
+		DWORD dwFourCC;
+		DWORD dwRGBBitCount;
+		DWORD dwRBitMask;
+		DWORD dwGBitMask;
+		DWORD dwBBitMask;
+		DWORD dwABitMask;
+	};
+
+	struct SDDSHeader
+	{
+		DWORD dwSize;
+		DWORD dwFlags;
+		DWORD dwHeight;
+		DWORD dwWidth;
+		DWORD dwPitchOrLinearSize;
+		DWORD dwDepth;
+		DWORD dwMipMapCount;
+		DWORD adwReserved1[11];
+		SDDSPixelFormat kPixelFormat;
+		DWORD dwCaps;
+		DWORD dwCaps2;
+		DWORD dwCaps3;
+		DWORD dwCaps4;
+		DWORD dwReserved2;
+	};
+#pragma pack(pop)
+
+	const DWORD DDS_MAGIC = 0x20534444;			// "DDS "
+	const DWORD DDSPF_ALPHAPIXELS = 0x00000001;
+	const DWORD DDSPF_ALPHA = 0x00000002;
+	const DWORD DDSPF_FOURCC = 0x00000004;
+	const DWORD DDSPF_LUMINANCE = 0x00020000;
+
+	// Per-channel mask -> 8-bit expansion, precomputed once per image.
+	struct SChannelReader
+	{
+		DWORD dwMask;
+		DWORD dwShift;
+		DWORD dwMax;
+		BYTE byDefault;
+
+		void Setup(DWORD dwChannelMask, BYTE byDefaultValue)
+		{
+			dwMask = dwChannelMask;
+			dwShift = 0;
+			byDefault = byDefaultValue;
+			if (dwMask)
+			{
+				DWORD dwProbe = dwMask;
+				while (!(dwProbe & 1))
+				{
+					dwProbe >>= 1;
+					++dwShift;
+				}
+				dwMax = dwProbe;
+			}
+			else
+			{
+				dwMax = 0;
+			}
+		}
+
+		BYTE Read(DWORD dwPixel) const
+		{
+			if (!dwMask)
+				return byDefault;
+			return BYTE(((dwPixel & dwMask) >> dwShift) * 255 / dwMax);
+		}
+	};
+
+	// Uncompressed DDS (masked RGB/luminance). The DXT formats never reach this
+	// decoder - CDXTCImage claims them first - but D3DX also accepted plain
+	// uncompressed .dds files, which the client's effect/UI assets use.
+	bool DecodeUncompressedDDS(const BYTE* c_pbyBuf, UINT uBufSize, SDecodedImage* pkRetImage)
+	{
+		if (uBufSize < sizeof(DWORD) + sizeof(SDDSHeader))
+			return false;
+
+		const SDDSHeader* pkHeader = reinterpret_cast<const SDDSHeader*>(c_pbyBuf + sizeof(DWORD));
+		if (pkHeader->dwSize != sizeof(SDDSHeader) || pkHeader->kPixelFormat.dwSize != sizeof(SDDSPixelFormat))
+			return false;
+		if (pkHeader->kPixelFormat.dwFlags & DDSPF_FOURCC)
+			return false;
+
+		const UINT uWidth = pkHeader->dwWidth;
+		const UINT uHeight = pkHeader->dwHeight;
+		const UINT uBitCount = pkHeader->kPixelFormat.dwRGBBitCount;
+		if (0 == uWidth || 0 == uHeight)
+			return false;
+		if (uBitCount != 8 && uBitCount != 16 && uBitCount != 24 && uBitCount != 32)
+			return false;
+
+		const UINT uBytesPerPixel = uBitCount / 8;
+		const UINT uPitch = uWidth * uBytesPerPixel;
+		const UINT uDataOffset = sizeof(DWORD) + sizeof(SDDSHeader);
+		if (uDataOffset + size_t(uPitch) * uHeight > uBufSize)
+			return false;
+
+		DWORD dwRMask = pkHeader->kPixelFormat.dwRBitMask;
+		DWORD dwGMask = pkHeader->kPixelFormat.dwGBitMask;
+		DWORD dwBMask = pkHeader->kPixelFormat.dwBBitMask;
+		const DWORD dwAMask = (pkHeader->kPixelFormat.dwFlags & (DDSPF_ALPHAPIXELS | DDSPF_ALPHA)) ? pkHeader->kPixelFormat.dwABitMask : 0;
+
+		if (pkHeader->kPixelFormat.dwFlags & DDSPF_LUMINANCE)
+			dwRMask = dwGMask = dwBMask = pkHeader->kPixelFormat.dwRBitMask;
+
+		SChannelReader kR, kG, kB, kA;
+		kR.Setup(dwRMask, 0);
+		kG.Setup(dwGMask, 0);
+		kB.Setup(dwBMask, 0);
+		kA.Setup(dwAMask, 0xFF);
+
+		pkRetImage->uWidth = uWidth;
+		pkRetImage->uHeight = uHeight;
+		pkRetImage->kPixels.resize(size_t(uWidth) * uHeight * 4);
+
+		const BYTE* pbySrcRow = c_pbyBuf + uDataOffset;
+		BYTE* pbyDst = pkRetImage->kPixels.data();
+
+		for (UINT y = 0; y < uHeight; ++y)
+		{
+			const BYTE* pbySrc = pbySrcRow;
+			for (UINT x = 0; x < uWidth; ++x)
+			{
+				DWORD dwPixel = 0;
+				for (UINT b = 0; b < uBytesPerPixel; ++b)
+					dwPixel |= DWORD(pbySrc[b]) << (b * 8);
+				pbySrc += uBytesPerPixel;
+
+				pbyDst[0] = kB.Read(dwPixel);
+				pbyDst[1] = kG.Read(dwPixel);
+				pbyDst[2] = kR.Read(dwPixel);
+				pbyDst[3] = kA.Read(dwPixel);
+				pbyDst += 4;
+			}
+			pbySrcRow += uPitch;
+		}
+
+		return true;
+	}
+
+#pragma pack(push, 1)
+	struct STGAHeader
+	{
+		BYTE byIDLength;
+		BYTE byColorMapType;
+		BYTE byImageType;
+		BYTE abyColorMapSpec[5];
+		WORD wXOrigin;
+		WORD wYOrigin;
+		WORD wWidth;
+		WORD wHeight;
+		BYTE byBitsPerPixel;
+		BYTE byDescriptor;
+	};
+#pragma pack(pop)
+
+	// TGA has no magic number; accept only the shapes the client ships
+	// (true-color, optionally RLE, 24/32bpp, no color map).
+	bool IsPlausibleTGA(const BYTE* c_pbyBuf, UINT uBufSize)
+	{
+		if (uBufSize < sizeof(STGAHeader))
+			return false;
+
+		const STGAHeader* pkHeader = reinterpret_cast<const STGAHeader*>(c_pbyBuf);
+		if (pkHeader->byColorMapType != 0)
+			return false;
+		if (pkHeader->byImageType != 2 && pkHeader->byImageType != 10)
+			return false;
+		if (pkHeader->byBitsPerPixel != 24 && pkHeader->byBitsPerPixel != 32)
+			return false;
+		if (pkHeader->wWidth == 0 || pkHeader->wHeight == 0)
+			return false;
+
+		return true;
+	}
+
+	bool DecodeTGA(const BYTE* c_pbyBuf, UINT uBufSize, SDecodedImage* pkRetImage)
+	{
+		const STGAHeader* pkHeader = reinterpret_cast<const STGAHeader*>(c_pbyBuf);
+
+		const UINT uWidth = pkHeader->wWidth;
+		const UINT uHeight = pkHeader->wHeight;
+		const UINT uSrcPixelSize = pkHeader->byBitsPerPixel / 8;
+		const bool bTopDown = (pkHeader->byDescriptor & 0x20) != 0;
+		const bool bRLE = (pkHeader->byImageType == 10);
+
+		UINT uPos = UINT(sizeof(STGAHeader)) + pkHeader->byIDLength;
+		if (uPos > uBufSize)
+			return false;
+
+		pkRetImage->uWidth = uWidth;
+		pkRetImage->uHeight = uHeight;
+		pkRetImage->kPixels.resize(size_t(uWidth) * uHeight * 4);
+
+		const UINT uPixelCount = uWidth * uHeight;
+		UINT uDecoded = 0;
+		BYTE abyPixel[4] = { 0, 0, 0, 0xFF };
+
+		// Decode into TGA storage order first (row 0 = bottom unless top-down).
+		std::vector<BYTE>& rkOut = pkRetImage->kPixels;
+		auto emit = [&](void) {
+			// Storage row -> top-down row.
+			UINT uRow = uDecoded / uWidth;
+			UINT uCol = uDecoded % uWidth;
+			if (!bTopDown)
+				uRow = uHeight - 1 - uRow;
+			BYTE* pbyDst = &rkOut[(size_t(uRow) * uWidth + uCol) * 4];
+			pbyDst[0] = abyPixel[0];	// B
+			pbyDst[1] = abyPixel[1];	// G
+			pbyDst[2] = abyPixel[2];	// R
+			pbyDst[3] = abyPixel[3];	// A
+			++uDecoded;
+		};
+
+		if (!bRLE)
+		{
+			if (uPos + size_t(uPixelCount) * uSrcPixelSize > uBufSize)
+				return false;
+
+			for (UINT i = 0; i < uPixelCount; ++i)
+			{
+				abyPixel[0] = c_pbyBuf[uPos];
+				abyPixel[1] = c_pbyBuf[uPos + 1];
+				abyPixel[2] = c_pbyBuf[uPos + 2];
+				abyPixel[3] = (uSrcPixelSize == 4) ? c_pbyBuf[uPos + 3] : 0xFF;
+				uPos += uSrcPixelSize;
+				emit();
+			}
+		}
+		else
+		{
+			while (uDecoded < uPixelCount)
+			{
+				if (uPos >= uBufSize)
+					return false;
+
+				const BYTE byPacket = c_pbyBuf[uPos++];
+				const UINT uRunLength = (byPacket & 0x7F) + 1;
+
+				if (byPacket & 0x80)
+				{
+					if (uPos + uSrcPixelSize > uBufSize || uDecoded + uRunLength > uPixelCount)
+						return false;
+
+					abyPixel[0] = c_pbyBuf[uPos];
+					abyPixel[1] = c_pbyBuf[uPos + 1];
+					abyPixel[2] = c_pbyBuf[uPos + 2];
+					abyPixel[3] = (uSrcPixelSize == 4) ? c_pbyBuf[uPos + 3] : 0xFF;
+					uPos += uSrcPixelSize;
+
+					for (UINT i = 0; i < uRunLength; ++i)
+						emit();
+				}
+				else
+				{
+					if (uPos + size_t(uRunLength) * uSrcPixelSize > uBufSize || uDecoded + uRunLength > uPixelCount)
+						return false;
+
+					for (UINT i = 0; i < uRunLength; ++i)
+					{
+						abyPixel[0] = c_pbyBuf[uPos];
+						abyPixel[1] = c_pbyBuf[uPos + 1];
+						abyPixel[2] = c_pbyBuf[uPos + 2];
+						abyPixel[3] = (uSrcPixelSize == 4) ? c_pbyBuf[uPos + 3] : 0xFF;
+						uPos += uSrcPixelSize;
+						emit();
+					}
+				}
+			}
+		}
+
+		return true;
+	}
+
+	bool DecodeWIC(const BYTE* c_pbyBuf, UINT uBufSize, SDecodedImage* pkRetImage)
+	{
+		// WIC needs COM; tolerate an already-initialized thread with a different model.
+		HRESULT hrCoInit = CoInitializeEx(NULL, COINIT_APARTMENTTHREADED);
+		const bool bBalanceCoInit = SUCCEEDED(hrCoInit);
+
+		bool bResult = false;
+		IWICImagingFactory* pkFactory = NULL;
+		IWICStream* pkStream = NULL;
+		IWICBitmapDecoder* pkDecoder = NULL;
+		IWICBitmapFrameDecode* pkFrame = NULL;
+		IWICBitmapSource* pkConverted = NULL;
+
+		do
+		{
+			if (FAILED(CoCreateInstance(CLSID_WICImagingFactory, NULL, CLSCTX_INPROC_SERVER,
+										IID_IWICImagingFactory, (void**)&pkFactory)))
+				break;
+			if (FAILED(pkFactory->CreateStream(&pkStream)))
+				break;
+			if (FAILED(pkStream->InitializeFromMemory(const_cast<BYTE*>(c_pbyBuf), uBufSize)))
+				break;
+			if (FAILED(pkFactory->CreateDecoderFromStream(pkStream, NULL, WICDecodeMetadataCacheOnDemand, &pkDecoder)))
+				break;
+			if (FAILED(pkDecoder->GetFrame(0, &pkFrame)))
+				break;
+			if (FAILED(WICConvertBitmapSource(GUID_WICPixelFormat32bppBGRA, pkFrame, &pkConverted)))
+				break;
+
+			UINT uWidth = 0, uHeight = 0;
+			if (FAILED(pkConverted->GetSize(&uWidth, &uHeight)) || 0 == uWidth || 0 == uHeight)
+				break;
+
+			pkRetImage->uWidth = uWidth;
+			pkRetImage->uHeight = uHeight;
+			pkRetImage->kPixels.resize(size_t(uWidth) * uHeight * 4);
+
+			if (FAILED(pkConverted->CopyPixels(NULL, uWidth * 4, UINT(pkRetImage->kPixels.size()), pkRetImage->kPixels.data())))
+				break;
+
+			bResult = true;
+		} while (false);
+
+		if (pkConverted)
+			pkConverted->Release();
+		if (pkFrame)
+			pkFrame->Release();
+		if (pkDecoder)
+			pkDecoder->Release();
+		if (pkStream)
+			pkStream->Release();
+		if (pkFactory)
+			pkFactory->Release();
+		if (bBalanceCoInit)
+			CoUninitialize();
+
+		return bResult;
+	}
+}
+
+bool DecodeImageFileFromMemory(const void* c_pvBuf, UINT uBufSize, SDecodedImage* pkRetImage)
+{
+	const BYTE* c_pbyBuf = static_cast<const BYTE*>(c_pvBuf);
+
+	// Known magics first; TGA has none, so it is probed last.
+	const bool bDDS = uBufSize >= 4 && *(const DWORD*)c_pbyBuf == DDS_MAGIC;
+	const bool bJPG = uBufSize >= 2 && c_pbyBuf[0] == 0xFF && c_pbyBuf[1] == 0xD8;
+	const bool bBMP = uBufSize >= 2 && c_pbyBuf[0] == 'B' && c_pbyBuf[1] == 'M';
+	const bool bPNG = uBufSize >= 8 && 0 == memcmp(c_pbyBuf, "\x89PNG\r\n\x1a\n", 8);
+
+	if (bDDS)
+		return DecodeUncompressedDDS(c_pbyBuf, uBufSize, pkRetImage);
+
+	if (bJPG || bBMP || bPNG)
+		return DecodeWIC(c_pbyBuf, uBufSize, pkRetImage);
+
+	if (IsPlausibleTGA(c_pbyBuf, uBufSize))
+		return DecodeTGA(c_pbyBuf, uBufSize, pkRetImage);
+
+	return false;
+}

--- a/Lead-Client-Source/EterLib/ImageFileDecoder.h
+++ b/Lead-Client-Source/EterLib/ImageFileDecoder.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <windows.h>
+#include <vector>
+
+// Decoded 32-bit B8G8R8A8 image (rows top-down, tightly packed).
+struct SDecodedImage
+{
+	UINT uWidth;
+	UINT uHeight;
+	std::vector<BYTE> kPixels;
+};
+
+// Decodes an uncompressed DDS (any masked RGB/luminance format), a TGA
+// (type 2/10, 24/32bpp) or a WIC-supported (JPG/BMP/PNG) image file held in
+// memory. DXT-compressed DDS is handled elsewhere (CDXTCImage). Returns false
+// on unknown or malformed input.
+bool DecodeImageFileFromMemory(const void* c_pvBuf, UINT uBufSize, SDecodedImage* pkRetImage);


### PR DESCRIPTION
Funnels the EterLib resource creations (image/DDS/decoded textures, block texture, vertex/index buffers) through the CGraphicBase factory seam.

Part of the DX9→DX12 migration (17b). Depends on #170 (edits its texture-loader code) and #183 (the factory API) - review only the last commit. Debug|x64 builds 0/0.
