### PR TITLE
refactor(client): create GameLib render resources via factory

### DIFF
--- a/Lead-Client-Source/EterLib/GrpBase.cpp
+++ b/Lead-Client-Source/EterLib/GrpBase.cpp
@@ -239,7 +239,7 @@ void CGraphicBase::SetSimpleCamera(float x, float y, float z, float pitch, float
 	UpdateViewMatrix();
 
 	// This is levites's virtual(?) code which you should not trust.
-	ms_lpd3dDevice->GetTransform(D3DTS_WORLD, &ms_matWorld);
+	STATEMANAGER.GetTransform(D3DTS_WORLD, &ms_matWorld);
 	D3DXMatrixMultiply(&ms_matWorldView, &ms_matWorld, &ms_matView);
 }
 
@@ -256,7 +256,7 @@ void CGraphicBase::SetAroundCamera(float distance, float pitch, float roll, floa
 	UpdateViewMatrix();
 
 	// This is levites's virtual(?) code which you should not trust.
-	ms_lpd3dDevice->GetTransform(D3DTS_WORLD, &ms_matWorld);
+	STATEMANAGER.GetTransform(D3DTS_WORLD, &ms_matWorld);
 	D3DXMatrixMultiply(&ms_matWorldView, &ms_matWorld, &ms_matView);
 }
 
@@ -504,6 +504,31 @@ void CGraphicBase::ResetFaceCount()
 HRESULT CGraphicBase::GetLastResult()
 {
 	return ms_hLastResult;
+}
+
+HRESULT CGraphicBase::CreateDeviceTexture(UINT uWidth, UINT uHeight, UINT uLevels, DWORD dwUsage, D3DFORMAT eFormat, D3DPOOL ePool, LPDIRECT3DTEXTURE9* ppTexture)
+{
+	return ms_lpd3dDevice->CreateTexture(uWidth, uHeight, uLevels, dwUsage, eFormat, ePool, ppTexture, NULL);
+}
+
+HRESULT CGraphicBase::CreateDeviceVertexBuffer(UINT uLength, DWORD dwUsage, DWORD dwFVF, D3DPOOL ePool, LPDIRECT3DVERTEXBUFFER9* ppVertexBuffer)
+{
+	return ms_lpd3dDevice->CreateVertexBuffer(uLength, dwUsage, dwFVF, ePool, ppVertexBuffer, NULL);
+}
+
+HRESULT CGraphicBase::CreateDeviceIndexBuffer(UINT uLength, DWORD dwUsage, D3DFORMAT eFormat, D3DPOOL ePool, LPDIRECT3DINDEXBUFFER9* ppIndexBuffer)
+{
+	return ms_lpd3dDevice->CreateIndexBuffer(uLength, dwUsage, eFormat, ePool, ppIndexBuffer, NULL);
+}
+
+HRESULT CGraphicBase::CreateDeviceDepthStencilSurface(UINT uWidth, UINT uHeight, D3DFORMAT eFormat, D3DMULTISAMPLE_TYPE eMultiSample, DWORD dwMultisampleQuality, BOOL bDiscard, LPDIRECT3DSURFACE9* ppSurface)
+{
+	return ms_lpd3dDevice->CreateDepthStencilSurface(uWidth, uHeight, eFormat, eMultiSample, dwMultisampleQuality, bDiscard, ppSurface, NULL);
+}
+
+HRESULT CGraphicBase::UpdateDeviceTexture(LPDIRECT3DBASETEXTURE9 pSourceTexture, LPDIRECT3DBASETEXTURE9 pDestinationTexture)
+{
+	return ms_lpd3dDevice->UpdateTexture(pSourceTexture, pDestinationTexture);
 }
 
 CGraphicBase::CGraphicBase()

--- a/Lead-Client-Source/EterLib/GrpBase.h
+++ b/Lead-Client-Source/EterLib/GrpBase.h
@@ -216,6 +216,14 @@ class CGraphicBase
 		static void SetDefaultIndexBuffer(UINT eDefIB);
 		static bool SetPDTStream(SPDTVertexRaw* pVertices, UINT uVtxCount);
 		static bool SetPDTStream(SPDTVertex* pVertices, UINT uVtxCount);
+
+		// Resource-creation seam: every device object the renderer allocates
+		// goes through these, so a future backend can swap allocation in one place.
+		static HRESULT CreateDeviceTexture(UINT uWidth, UINT uHeight, UINT uLevels, DWORD dwUsage, D3DFORMAT eFormat, D3DPOOL ePool, LPDIRECT3DTEXTURE9* ppTexture);
+		static HRESULT CreateDeviceVertexBuffer(UINT uLength, DWORD dwUsage, DWORD dwFVF, D3DPOOL ePool, LPDIRECT3DVERTEXBUFFER9* ppVertexBuffer);
+		static HRESULT CreateDeviceIndexBuffer(UINT uLength, DWORD dwUsage, D3DFORMAT eFormat, D3DPOOL ePool, LPDIRECT3DINDEXBUFFER9* ppIndexBuffer);
+		static HRESULT CreateDeviceDepthStencilSurface(UINT uWidth, UINT uHeight, D3DFORMAT eFormat, D3DMULTISAMPLE_TYPE eMultiSample, DWORD dwMultisampleQuality, BOOL bDiscard, LPDIRECT3DSURFACE9* ppSurface);
+		static HRESULT UpdateDeviceTexture(LPDIRECT3DBASETEXTURE9 pSourceTexture, LPDIRECT3DBASETEXTURE9 pDestinationTexture);
 		
 	protected:
 		static D3DXMATRIX				ms_matIdentity;

--- a/Lead-Client-Source/GameLib/AreaTerrain.cpp
+++ b/Lead-Client-Source/GameLib/AreaTerrain.cpp
@@ -781,9 +781,9 @@ LPDIRECT3DTEXTURE9 CTerrain::AddTexture32(BYTE byImageNum, BYTE * pbyImage, long
 
 	UINT uiNewWidth = 256;
 	UINT uiNewHeight = 256;
-	hr = ms_lpd3dDevice->CreateTexture(
-		uiNewWidth, uiNewHeight, 5, D3DUSAGE_DYNAMIC, 
-		format, D3DPOOL_DEFAULT, &pkTex, NULL);
+	hr = CreateDeviceTexture(
+		uiNewWidth, uiNewHeight, 5, D3DUSAGE_DYNAMIC,
+		format, D3DPOOL_DEFAULT, &pkTex);
 	if (FAILED(hr))
 	{
 		TraceError("CTerrain::AddTexture32 - CreateTexture failed hr=0x%08X w=%u h=%u levels=%u usage=%u fmt=%u pool=%u", hr, uiNewWidth, uiNewHeight, 5u, (unsigned)D3DUSAGE_DYNAMIC, (unsigned)format, (unsigned)D3DPOOL_DEFAULT);
@@ -1151,23 +1151,26 @@ void CTerrain::AllocateMarkedSplats(BYTE * pbyAlphaMap)
 		} while(ulRef > 0);
 	}
 
-	do
+	hr = CreateDeviceTexture(ATTRMAP_XSIZE, ATTRMAP_YSIZE, 1, D3DUSAGE_DYNAMIC, D3DFMT_A8R8G8B8, D3DPOOL_DEFAULT, &m_lpMarkedTexture);
+	if (FAILED(hr))
 	{
-		hr = ms_lpd3dDevice->CreateTexture(ATTRMAP_XSIZE, ATTRMAP_YSIZE, 1, D3DUSAGE_DYNAMIC, D3DFMT_A8R8G8B8, D3DPOOL_DEFAULT, &m_lpMarkedTexture, NULL);
-	} while(FAILED(hr));
+		TraceError("CTerrain::AllocateMarkedSplats - CreateTexture failed hr=0x%08X", hr);
+		return;
+	}
 
 	D3DLOCKED_RECT d3dlr;
-	do
+	hr = m_lpMarkedTexture->LockRect(0, &d3dlr, 0, 0);
+	if (FAILED(hr))
 	{
-		hr = m_lpMarkedTexture->LockRect(0, &d3dlr, 0, 0);
-	} while(FAILED(hr));
+		TraceError("CTerrain::AllocateMarkedSplats - LockRect failed hr=0x%08X", hr);
+		m_lpMarkedTexture->Release();
+		m_lpMarkedTexture = NULL;
+		return;
+	}
 
 	PutImage32(pbyAlphaMap, (BYTE*) d3dlr.pBits, ATTRMAP_XSIZE, d3dlr.Pitch, ATTRMAP_XSIZE, ATTRMAP_YSIZE);
 
-	do
-	{
-		hr = m_lpMarkedTexture->UnlockRect(0);
-	} while(FAILED(hr));
+	m_lpMarkedTexture->UnlockRect(0);
 
 	rAttrSplat.pd3dTexture = m_lpMarkedTexture;
 	m_bMarked = true;

--- a/Lead-Client-Source/GameLib/MapOutdoorCharacterShadow.cpp
+++ b/Lead-Client-Source/GameLib/MapOutdoorCharacterShadow.cpp
@@ -32,9 +32,28 @@ void CMapOutdoor::CreateCharacterShadowTexture()
 	m_ShadowMapViewport.MinZ = 0.0f;
 	m_ShadowMapViewport.MaxZ = 1.0f;
 
-	ms_lpd3dDevice->CreateTexture(m_wShadowMapSize, m_wShadowMapSize, 1, D3DUSAGE_RENDERTARGET, D3DFMT_R5G6B5, D3DPOOL_DEFAULT, &m_lpCharacterShadowMapTexture, NULL);
-	m_lpCharacterShadowMapTexture->GetSurfaceLevel(0, &m_lpCharacterShadowMapRenderTargetSurface);
-	ms_lpd3dDevice->CreateDepthStencilSurface(m_wShadowMapSize, m_wShadowMapSize, D3DFMT_D16, D3DMULTISAMPLE_NONE, 0, TRUE, &m_lpCharacterShadowMapDepthSurface, NULL);
+	HRESULT hr = CreateDeviceTexture(m_wShadowMapSize, m_wShadowMapSize, 1, D3DUSAGE_RENDERTARGET, D3DFMT_R5G6B5, D3DPOOL_DEFAULT, &m_lpCharacterShadowMapTexture);
+	if (FAILED(hr))
+	{
+		TraceError("CMapOutdoor::CreateCharacterShadowTexture - CreateTexture failed hr=0x%08X", hr);
+		return;
+	}
+
+	hr = m_lpCharacterShadowMapTexture->GetSurfaceLevel(0, &m_lpCharacterShadowMapRenderTargetSurface);
+	if (FAILED(hr))
+	{
+		TraceError("CMapOutdoor::CreateCharacterShadowTexture - GetSurfaceLevel failed hr=0x%08X", hr);
+		ReleaseCharacterShadowTexture();
+		return;
+	}
+
+	hr = CreateDeviceDepthStencilSurface(m_wShadowMapSize, m_wShadowMapSize, D3DFMT_D16, D3DMULTISAMPLE_NONE, 0, TRUE, &m_lpCharacterShadowMapDepthSurface);
+	if (FAILED(hr))
+	{
+		TraceError("CMapOutdoor::CreateCharacterShadowTexture - CreateDepthStencilSurface failed hr=0x%08X", hr);
+		ReleaseCharacterShadowTexture();
+		return;
+	}
 }
 
 void CMapOutdoor::ReleaseCharacterShadowTexture()

--- a/Lead-Client-Source/GameLib/SnowEnvironment.cpp
+++ b/Lead-Client-Source/GameLib/SnowEnvironment.cpp
@@ -234,11 +234,11 @@ bool CSnowEnvironment::__CreateBlurTexture()
 	if (!m_bBlurEnable)
 		return true;
 
-	if (FAILED(ms_lpd3dDevice->CreateTexture(m_wBlurTextureSize, m_wBlurTextureSize, 1, D3DUSAGE_RENDERTARGET, D3DFMT_X8R8G8B8, D3DPOOL_DEFAULT, &m_lpSnowTexture, NULL)))
+	if (FAILED(CreateDeviceTexture(m_wBlurTextureSize, m_wBlurTextureSize, 1, D3DUSAGE_RENDERTARGET, D3DFMT_X8R8G8B8, D3DPOOL_DEFAULT, &m_lpSnowTexture)))
 		return false;
 	if (FAILED(m_lpSnowTexture->GetSurfaceLevel(0, &m_lpSnowRenderTargetSurface)))
 		return false;
-	if (FAILED(ms_lpd3dDevice->CreateDepthStencilSurface(m_wBlurTextureSize, m_wBlurTextureSize, D3DFMT_D16, D3DMULTISAMPLE_NONE, 0, TRUE, &m_lpSnowDepthSurface, NULL)))
+	if (FAILED(CreateDeviceDepthStencilSurface(m_wBlurTextureSize, m_wBlurTextureSize, D3DFMT_D16, D3DMULTISAMPLE_NONE, 0, TRUE, &m_lpSnowDepthSurface)))
 		return false;
 
 	if (FAILED(ms_lpd3dDevice->CreateTexture(m_wBlurTextureSize, m_wBlurTextureSize, 1, D3DUSAGE_RENDERTARGET, D3DFMT_X8R8G8B8, D3DPOOL_DEFAULT, &m_lpAccumTexture, NULL)))
@@ -253,18 +253,18 @@ bool CSnowEnvironment::__CreateBlurTexture()
 
 bool CSnowEnvironment::__CreateGeometry()
 {
-	if (FAILED(ms_lpd3dDevice->CreateVertexBuffer(sizeof(SParticleVertex)*m_dwParticleMaxNum*4,
+	if (FAILED(CreateDeviceVertexBuffer(sizeof(SParticleVertex)*m_dwParticleMaxNum*4,
 											D3DUSAGE_DYNAMIC|D3DUSAGE_WRITEONLY,
 											D3DFVF_XYZ | D3DFVF_TEX1,
 											D3DPOOL_DEFAULT,
-											&m_pVB, NULL)))
+											&m_pVB)))
 		return false;
 
-	if (FAILED(ms_lpd3dDevice->CreateIndexBuffer(sizeof(WORD)*m_dwParticleMaxNum*6,
+	if (FAILED(CreateDeviceIndexBuffer(sizeof(WORD)*m_dwParticleMaxNum*6,
 										   D3DUSAGE_DYNAMIC,
 										   D3DFMT_INDEX16,
 										   D3DPOOL_DEFAULT,
-										   &m_pIB, NULL)))
+										   &m_pIB)))
 		return false;
 
 	WORD* dstIndices;


### PR DESCRIPTION
Routes GameLib resource creation through the CGraphicBase factory (terrain textures, character shadow map + depth surface, snow blur target + particle buffers). Also hardens failure paths: the marked-splat allocator's infinite do/while retries become checked single attempts, and the previously unchecked shadow-map creations now validate and release on failure.

Part of the DX9→DX12 migration (18). Depends on #183 (the factory API) - review only the last commit. Debug|x64 builds 0/0.
