### PR TITLE
feat(client): route Present and back-buffer access through StateManager

### DIFF
--- a/Lead-Client-Source/EterLib/GrpScreen.cpp
+++ b/Lead-Client-Source/EterLib/GrpScreen.cpp
@@ -676,27 +676,27 @@ void CScreen::Show(HWND hWnd)
 		RECT rcLeft = { 0, g_rcBrowser.top, g_rcBrowser.left, g_rcBrowser.bottom };
 		RECT rcRight = { g_rcBrowser.right, g_rcBrowser.top, (LONG)ms_d3dPresentParameter.BackBufferWidth, g_rcBrowser.bottom };
 		
-		ms_lpd3dDevice->PresentEx(&rcTop, &rcTop, hWnd, NULL, 0);
-		ms_lpd3dDevice->PresentEx(&rcBottom, &rcBottom, hWnd, NULL, 0);
-		ms_lpd3dDevice->PresentEx(&rcLeft, &rcLeft, hWnd, NULL, 0);	
-		ms_lpd3dDevice->PresentEx(&rcRight, &rcRight, hWnd, NULL, 0);
+		STATEMANAGER.Present(&rcTop, &rcTop, hWnd);
+		STATEMANAGER.Present(&rcBottom, &rcBottom, hWnd);
+		STATEMANAGER.Present(&rcLeft, &rcLeft, hWnd);
+		STATEMANAGER.Present(&rcRight, &rcRight, hWnd);
 	}
 	else
 	{
-		ms_lpd3dDevice->PresentEx(NULL, NULL, hWnd, NULL, 0);
+		STATEMANAGER.Present(NULL, NULL, hWnd);
 	}	
 }
 
 void CScreen::Show(RECT * pSrcRect)
 {
 	assert(ms_lpd3dDevice != NULL);
-	ms_lpd3dDevice->PresentEx(pSrcRect, NULL, NULL, NULL, 0);
+	STATEMANAGER.Present(pSrcRect, NULL, NULL);
 }
 
 void CScreen::Show(RECT * pSrcRect, HWND hWnd)
 {
 	assert(ms_lpd3dDevice != NULL);
-	ms_lpd3dDevice->PresentEx(pSrcRect, NULL, hWnd, NULL, 0);
+	STATEMANAGER.Present(pSrcRect, NULL, hWnd);
 }
 
 void CScreen::ProjectPosition(float x, float y, float z, float * pfX, float * pfY)

--- a/Lead-Client-Source/EterLib/StateManager.cpp
+++ b/Lead-Client-Source/EterLib/StateManager.cpp
@@ -54,6 +54,16 @@ void CStateManager::EndScene()
 	m_bScene=false;
 }
 
+HRESULT CStateManager::Present(CONST RECT* pSourceRect, CONST RECT* pDestRect, HWND hDestWindowOverride)
+{
+	return m_lpD3DDev->PresentEx(pSourceRect, pDestRect, hDestWindowOverride, NULL, 0);
+}
+
+HRESULT CStateManager::GetBackBuffer(UINT iSwapChain, UINT iBackBuffer, D3DBACKBUFFER_TYPE eType, LPDIRECT3DSURFACE9* ppBackBuffer)
+{
+	return m_lpD3DDev->GetBackBuffer(iSwapChain, iBackBuffer, eType, ppBackBuffer);
+}
+
 CStateManager::CStateManager(LPDIRECT3DDEVICE9EX lpDevice) : m_lpD3DDev(NULL)
 {
 	m_bScene = false;

--- a/Lead-Client-Source/EterLib/StateManager.h
+++ b/Lead-Client-Source/EterLib/StateManager.h
@@ -245,6 +245,8 @@ class CStateManager : public CSingleton<CStateManager>
 
 		bool	BeginScene();
 		void	EndScene();
+		HRESULT	Present(CONST RECT* pSourceRect, CONST RECT* pDestRect, HWND hDestWindowOverride);
+		HRESULT	GetBackBuffer(UINT iSwapChain, UINT iBackBuffer, D3DBACKBUFFER_TYPE eType, LPDIRECT3DSURFACE9* ppBackBuffer);
 
 		// Material
 		void	SaveMaterial();

--- a/Lead-Client-Source/EterPythonLib/PythonGraphic.cpp
+++ b/Lead-Client-Source/EterPythonLib/PythonGraphic.cpp
@@ -175,7 +175,7 @@ bool CPythonGraphic::SaveScreenShot(const char * c_pszFileName)
 	LPDIRECT3DSURFACE9 lpSurface;
 	D3DSURFACE_DESC stSurfaceDesc;
 
-	if (FAILED(hr = ms_lpd3dDevice->GetBackBuffer(0, 0, D3DBACKBUFFER_TYPE_MONO, &lpSurface)))
+	if (FAILED(hr = STATEMANAGER.GetBackBuffer(0, 0, D3DBACKBUFFER_TYPE_MONO, &lpSurface)))
 	{
 		TraceError("Failed to get back buffer (0x%08x)", hr);
 		return false;


### PR DESCRIPTION
Adds CStateManager::Present (PresentEx pass-through) and GetBackBuffer next to the existing Begin/EndScene, and routes the seven PresentEx call sites (including the four-rect browser-mode path) and the screenshot back-buffer grab through them.

Part of the DX9→DX12 migration (21). Independent. Debug|x64 builds 0/0.
