### PR TITLE
refactor(client): expose caps/gamma/adapter queries via CGraphicBase, drop GetD3D

### DIFF
--- a/Lead-Client-Source/EterLib/GrpBase.cpp
+++ b/Lead-Client-Source/EterLib/GrpBase.cpp
@@ -506,6 +506,36 @@ HRESULT CGraphicBase::GetLastResult()
 	return ms_hLastResult;
 }
 
+bool CGraphicBase::SupportsFullscreenGamma()
+{
+	return D3DCAPS2_FULLSCREENGAMMA == (ms_d3dCaps.Caps2 & D3DCAPS2_FULLSCREENGAMMA);
+}
+
+void CGraphicBase::SetDeviceGammaRamp(CONST D3DGAMMARAMP* pRamp)
+{
+	ms_lpd3dDevice->SetGammaRamp(0, D3DSGR_NO_CALIBRATION, pRamp);
+}
+
+HRESULT CGraphicBase::GetAdapterIdentifier(D3DADAPTER_IDENTIFIER9* pIdentifier)
+{
+	return ms_lpd3d->GetAdapterIdentifier(0, 0, pIdentifier);
+}
+
+HRESULT CGraphicBase::GetAdapterDisplayMode(D3DDISPLAYMODE* pMode)
+{
+	return ms_lpd3d->GetAdapterDisplayMode(0, pMode);
+}
+
+UINT CGraphicBase::GetAdapterModeCount(D3DFORMAT eFormat)
+{
+	return ms_lpd3d->GetAdapterModeCount(0, eFormat);
+}
+
+HRESULT CGraphicBase::EnumAdapterModes(D3DFORMAT eFormat, UINT uMode, D3DDISPLAYMODE* pMode)
+{
+	return ms_lpd3d->EnumAdapterModes(0, eFormat, uMode, pMode);
+}
+
 CGraphicBase::CGraphicBase()
 {
 }

--- a/Lead-Client-Source/EterLib/GrpBase.h
+++ b/Lead-Client-Source/EterLib/GrpBase.h
@@ -208,6 +208,12 @@ class CGraphicBase
 		
 		void		SetViewport(DWORD dwX, DWORD dwY, DWORD dwWidth, DWORD dwHeight, float fMinZ, float fMaxZ);
 		static void		GetBackBufferSize(UINT* puWidth, UINT* puHeight);
+		static bool		SupportsFullscreenGamma();
+		static void		SetDeviceGammaRamp(CONST D3DGAMMARAMP* pRamp);
+		static HRESULT	GetAdapterIdentifier(D3DADAPTER_IDENTIFIER9* pIdentifier);
+		static HRESULT	GetAdapterDisplayMode(D3DDISPLAYMODE* pMode);
+		static UINT		GetAdapterModeCount(D3DFORMAT eFormat);
+		static HRESULT	EnumAdapterModes(D3DFORMAT eFormat, UINT uMode, D3DDISPLAYMODE* pMode);
 		static bool		IsTLVertexClipping();
 		static bool		IsFastTNL();
 		static bool		IsLowTextureMemory();

--- a/Lead-Client-Source/EterPythonLib/PythonGraphic.cpp
+++ b/Lead-Client-Source/EterPythonLib/PythonGraphic.cpp
@@ -9,11 +9,6 @@ void CPythonGraphic::Destroy()
 {	
 }
 
-LPDIRECT3D9EX CPythonGraphic::GetD3D()
-{
-	return ms_lpd3d;
-}
-
 float CPythonGraphic::GetOrthoDepth()
 {
 	return m_fOrthoDepth;
@@ -123,13 +118,10 @@ void CPythonGraphic::RestoreViewport()
 
 void CPythonGraphic::SetGamma(float fGammaFactor)
 {
-	D3DCAPS9		d3dCaps;
 	D3DGAMMARAMP	NewRamp;
 	int				ui, val;
-	
-	ms_lpd3dDevice->GetDeviceCaps(&d3dCaps);
 
-	if (D3DCAPS2_FULLSCREENGAMMA != (d3dCaps.Caps2 & D3DCAPS2_FULLSCREENGAMMA))
+	if (!SupportsFullscreenGamma())
 		return;
 
 	for (int i = 0; i < 256; ++i)
@@ -151,7 +143,7 @@ void CPythonGraphic::SetGamma(float fGammaFactor)
 		NewRamp.blue[i] = (WORD) (val | (32768 * ui));
 	}
 
-	ms_lpd3dDevice->SetGammaRamp(0, D3DSGR_NO_CALIBRATION, &NewRamp);
+	SetDeviceGammaRamp(&NewRamp);
 }
 
 void GenScreenShotTag(const char* src, DWORD crc32, char* leaf, size_t leafLen)
@@ -607,7 +599,7 @@ void CPythonGraphic::RenderUpButton(float sx, float sy, float ex, float ey)
 
 DWORD CPythonGraphic::GetAvailableMemory()
 {
-	return ms_lpd3dDevice->GetAvailableTextureMem();
+	return GetAvailableTextureMemory();
 }
 
 CPythonGraphic::CPythonGraphic()

--- a/Lead-Client-Source/EterPythonLib/PythonGraphic.h
+++ b/Lead-Client-Source/EterPythonLib/PythonGraphic.h
@@ -18,7 +18,6 @@ class CPythonGraphic : public CScreen, public CSingleton<CPythonGraphic>
 		void PushState();
 		void PopState();
 
-		LPDIRECT3D9EX GetD3D();
 
 		float GetOrthoDepth();
 		void SetInterfaceRenderState();

--- a/Lead-Client-Source/UserInterface/PythonSystem.cpp
+++ b/Lead-Client-Source/UserInterface/PythonSystem.cpp
@@ -36,21 +36,19 @@ void CPythonSystem::GetDisplaySettings()
 	memset(m_ResolutionList, 0, sizeof(TResolution) * RESOLUTION_MAX_NUM);
 	m_ResolutionCount = 0;
 
-	LPDIRECT3D9EX lpD3D = CPythonGraphic::Instance().GetD3D();
-
 	D3DADAPTER_IDENTIFIER9 d3dAdapterIdentifier;
 	D3DDISPLAYMODE d3ddmDesktop;
 
-	lpD3D->GetAdapterIdentifier(0, 0, &d3dAdapterIdentifier);
-	lpD3D->GetAdapterDisplayMode(0, &d3ddmDesktop);
+	CGraphicBase::GetAdapterIdentifier(&d3dAdapterIdentifier);
+	CGraphicBase::GetAdapterDisplayMode(&d3ddmDesktop);
 
 	// AI ¾iμªAI°¡ °¡Ao°i AO´A μ?½ºCA·¡AI ¸?μa°¹¼o¸| ³ª¿­CN´U..
-	DWORD dwNumAdapterModes = lpD3D->GetAdapterModeCount(0, d3ddmDesktop.Format);
+	DWORD dwNumAdapterModes = CGraphicBase::GetAdapterModeCount(d3ddmDesktop.Format);
 
 	for (UINT iMode = 0; iMode < dwNumAdapterModes; iMode++)
 	{
 		D3DDISPLAYMODE DisplayMode;
-		lpD3D->EnumAdapterModes(0, d3ddmDesktop.Format, iMode, &DisplayMode);
+		CGraphicBase::EnumAdapterModes(d3ddmDesktop.Format, iMode, &DisplayMode);
 		DWORD bpp = 0;
 
 		// Filters out only those above 800 and 600.


### PR DESCRIPTION
Adds CGraphicBase accessors for the remaining device/adapter queries (SupportsFullscreenGamma from cached caps, SetDeviceGammaRamp, adapter identifier/display-mode enumeration) and swaps the gamma-slider, available-memory and resolution-list code onto them. Deletes CPythonGraphic::GetD3D - no raw D3D interface leaves the graphics layer anymore.

Part of the DX9→DX12 migration (22). Independent. Debug|x64 builds 0/0.
