### PR TITLE
fix(client): bounds-check token vectors in area/property loaders

### DIFF
--- a/Lead-Client-Source/GameLib/Area.cpp
+++ b/Lead-Client-Source/GameLib/Area.cpp
@@ -927,6 +927,12 @@ bool CArea::__Load_LoadObject(const char * c_szFileName)
 
 		const CTokenVector & rVector = stTokenVectorMap[szObjectName];
 
+		if (rVector.size() < 4)
+		{
+			TraceError(" CArea::__LoadObject %s : object(%s) has %u tokens, need >= 4", c_szFileName, szObjectName, static_cast<unsigned>(rVector.size()));
+			continue;
+		}
+
 		const std::string & c_rstrxPosition = rVector[0].c_str();
 		const std::string & c_rstryPosition = rVector[1].c_str();
 		const std::string & c_rstrzPosition = rVector[2].c_str();
@@ -1024,6 +1030,12 @@ bool CArea::__Load_LoadAmbience(const char * c_szFileName)
 			continue;
 
 		const CTokenVector & rVector = stTokenVectorMap[szObjectName];
+
+		if (rVector.size() < 5)
+		{
+			TraceError(" CArea::__LoadAmbience %s : object(%s) has %u tokens, need >= 5", c_szFileName, szObjectName, static_cast<unsigned>(rVector.size()));
+			continue;
+		}
 
 		const std::string & c_rstrxPosition = rVector[0].c_str();
 		const std::string & c_rstryPosition = rVector[1].c_str();

--- a/Lead-Client-Source/GameLib/Property.cpp
+++ b/Lead-Client-Source/GameLib/Property.cpp
@@ -47,6 +47,12 @@ bool CProperty::GetString(const char * c_pszKey, const char ** c_ppString)
 	if (m_stTokenMap.end() == it)
 		return false;
 
+	if (it->second.empty())
+	{
+		TraceError("CProperty::GetString : key(%s) in property(%s) has no value", c_pszKey, m_stFileName.c_str());
+		return false;
+	}
+
 	*c_ppString = it->second[0].c_str();
 	return true;
 }


### PR DESCRIPTION
Malformed/short object rows in a map's AreaData/AreaAmbience file (or an empty property value) caused `std::vector::operator[]` out-of-range while loading an outdoor map: a hard debug assert ("vector subscript out of range"), and a silent past-the-end read in Release.

Guard the fixed-slot token reads before they run, mirroring the size checks already present a few lines below each one:
- `CArea::__Load_LoadObject` — require >= 4 tokens
- `CArea::__Load_LoadAmbience` — require >= 5 tokens
- `CProperty::GetString` — skip empty value vectors

A short/empty row is now skipped with a `TraceError` naming the file/object instead of crashing. Pre-existing bug, independent of the DX12 work; builds clean on the pre-migration client (Debug|x64, 0 warn/0 err).