### PR TITLE
feat(client): decals, trails and lens flare through the shader pipeline

### DIFF
--- a/Lead-Client-Source/EterLib/Decal.cpp
+++ b/Lead-Client-Source/EterLib/Decal.cpp
@@ -227,7 +227,9 @@ void CDecal::Render()
 	D3DXMatrixIdentity(&matWorld);
 	STATEMANAGER.SetTransform(D3DTS_WORLD, &matWorld);
 	
-	STATEMANAGER.SetFVF(D3DFVF_XYZ | D3DFVF_DIFFUSE | D3DFVF_TEX1);
+	const bool bShaderPipeline = CGraphicBase::BeginPDTTextureShader();
+	if (!bShaderPipeline)
+		STATEMANAGER.SetFVF(D3DFVF_XYZ | D3DFVF_DIFFUSE | D3DFVF_TEX1);
 	
 	for (DWORD dwi = 0; dwi < m_TriangleFanStructVector.size(); ++dwi)
 		STATEMANAGER.DrawIndexedPrimitiveUP(D3DPT_TRIANGLEFAN,
@@ -238,6 +240,9 @@ void CDecal::Render()
 		D3DFMT_INDEX16,
 		m_Vertices,
 		sizeof(TPDTVertex));
+
+	if (bShaderPipeline)
+		CGraphicBase::EndPDTShader();
 }
 
 /*

--- a/Lead-Client-Source/EterLib/EterLib.vcxproj
+++ b/Lead-Client-Source/EterLib/EterLib.vcxproj
@@ -146,6 +146,7 @@
     <ClCompile Include="EnvironmentMap.cpp" />
     <ClCompile Include="FileLoaderThread.cpp" />
     <ClCompile Include="GrpBase.cpp" />
+    <ClCompile Include="GraphicShaderPool.cpp" />
     <ClCompile Include="GrpCollisionObject.cpp" />
     <ClCompile Include="GrpColor.cpp" />
     <ClCompile Include="GrpColorInstance.cpp" />
@@ -221,6 +222,7 @@
     <ClInclude Include="FileLoaderThread.h" />
     <ClInclude Include="FuncObject.h" />
     <ClInclude Include="GrpBase.h" />
+    <ClInclude Include="GraphicShaderPool.h" />
     <ClInclude Include="GrpCollisionObject.h" />
     <ClInclude Include="GrpColor.h" />
     <ClInclude Include="GrpColorInstance.h" />

--- a/Lead-Client-Source/EterLib/EterLib.vcxproj.filters
+++ b/Lead-Client-Source/EterLib/EterLib.vcxproj.filters
@@ -13,6 +13,7 @@
     <ClCompile Include="EnvironmentMap.cpp" />
     <ClCompile Include="FileLoaderThread.cpp" />
     <ClCompile Include="GrpBase.cpp" />
+    <ClCompile Include="GraphicShaderPool.cpp" />
     <ClCompile Include="GrpCollisionObject.cpp" />
     <ClCompile Include="GrpColor.cpp" />
     <ClCompile Include="GrpColorInstance.cpp" />
@@ -85,6 +86,7 @@
     <ClInclude Include="FileLoaderThread.h" />
     <ClInclude Include="FuncObject.h" />
     <ClInclude Include="GrpBase.h" />
+    <ClInclude Include="GraphicShaderPool.h" />
     <ClInclude Include="GrpCollisionObject.h" />
     <ClInclude Include="GrpColor.h" />
     <ClInclude Include="GrpColorInstance.h" />

--- a/Lead-Client-Source/EterLib/GraphicShaderPool.cpp
+++ b/Lead-Client-Source/EterLib/GraphicShaderPool.cpp
@@ -1,0 +1,1142 @@
+#include "StdAfx.h"
+#include <d3dcompiler.h>
+#include "../eterBase/Stl.h"
+#include "GraphicShaderPool.h"
+#include "StateManager.h"
+
+#pragma comment(lib, "d3dcompiler.lib")
+
+namespace
+{
+	// The fixed-function vertex-fog factor, evaluated exactly like D3D9 FFP:
+	// LINEAR ramp or EXP density on the (optionally radial) view-space distance,
+	// selected by the flags __Bind derives from the cached fog render states.
+	// Reads the transposed WORLDVIEW rows in c11-c13 and the params in c28-c29.
+	#define FOG_VS_PARAMS \
+		"float4 g_vFogParams : register(c28);\n" \
+		"float4 g_vFogParams2 : register(c29);\n"
+	#define FOG_VS_DECLARATIONS \
+		"float4 g_avWorldView[3] : register(c11);\n" \
+		FOG_VS_PARAMS
+	#define FOG_VS_BODY \
+		"    float3 vViewPos;\n" \
+		"    vViewPos.x = dot(vPosition, g_avWorldView[0]);\n" \
+		"    vViewPos.y = dot(vPosition, g_avWorldView[1]);\n" \
+		"    vViewPos.z = dot(vPosition, g_avWorldView[2]);\n" \
+		"    float fFogDist = lerp(vViewPos.z, length(vViewPos), g_vFogParams2.y);\n" \
+		"    Out.fFog = saturate(fFogDist * g_vFogParams.x + g_vFogParams.y) * g_vFogParams.z\n" \
+		"             + exp2(-fFogDist * g_vFogParams2.x) * g_vFogParams.w;\n"
+
+	// One WVP through dp4, matching the SpeedTree leaf shader convention.
+	const char c_achPDTVertexProgram[] =
+		"float4 g_avWVP[4] : register(c0);\n"
+		FOG_VS_DECLARATIONS
+		"struct VS_INPUT { float3 vPosition : POSITION; float4 vDiffuse : COLOR0; float2 vTexCoord : TEXCOORD0; };\n"
+		"struct VS_OUTPUT { float4 vPosition : POSITION; float4 vDiffuse : COLOR0; float2 vTexCoord : TEXCOORD0; float fFog : FOG; };\n"
+		"VS_OUTPUT main(VS_INPUT In)\n"
+		"{\n"
+		"    VS_OUTPUT Out;\n"
+		"    float4 vPosition = float4(In.vPosition, 1.0f);\n"
+		"    Out.vPosition.x = dot(vPosition, g_avWVP[0]);\n"
+		"    Out.vPosition.y = dot(vPosition, g_avWVP[1]);\n"
+		"    Out.vPosition.z = dot(vPosition, g_avWVP[2]);\n"
+		"    Out.vPosition.w = dot(vPosition, g_avWVP[3]);\n"
+		"    Out.vDiffuse = In.vDiffuse;\n"
+		"    Out.vTexCoord = In.vTexCoord;\n"
+		FOG_VS_BODY
+		"    return Out;\n"
+		"}\n";
+
+	// Fixed-function stage 0: COLOROP/ALPHAOP = MODULATE(TEXTURE, DIFFUSE).
+	const char c_achModulatePixelProgram[] =
+		"sampler2D g_kSampler0 : register(s0);\n"
+		"float4 main(float4 vDiffuse : COLOR0, float2 vTexCoord : TEXCOORD0) : COLOR0\n"
+		"{\n"
+		"    return tex2D(g_kSampler0, vTexCoord) * vDiffuse;\n"
+		"}\n";
+
+	// Fixed-function NULL-texture draw: only the interpolated diffuse reaches the output.
+	const char c_achDiffusePixelProgram[] =
+		"float4 main(float4 vDiffuse : COLOR0) : COLOR0\n"
+		"{\n"
+		"    return vDiffuse;\n"
+		"}\n";
+
+	// XYZ|TEX1 (no diffuse) through the same WVP.
+	const char c_achPTVertexProgram[] =
+		"float4 g_avWVP[4] : register(c0);\n"
+		FOG_VS_DECLARATIONS
+		"struct VS_INPUT { float3 vPosition : POSITION; float2 vTexCoord : TEXCOORD0; };\n"
+		"struct VS_OUTPUT { float4 vPosition : POSITION; float2 vTexCoord : TEXCOORD0; float fFog : FOG; };\n"
+		"VS_OUTPUT main(VS_INPUT In)\n"
+		"{\n"
+		"    VS_OUTPUT Out;\n"
+		"    float4 vPosition = float4(In.vPosition, 1.0f);\n"
+		"    Out.vPosition.x = dot(vPosition, g_avWVP[0]);\n"
+		"    Out.vPosition.y = dot(vPosition, g_avWVP[1]);\n"
+		"    Out.vPosition.z = dot(vPosition, g_avWVP[2]);\n"
+		"    Out.vPosition.w = dot(vPosition, g_avWVP[3]);\n"
+		"    Out.vTexCoord = In.vTexCoord;\n"
+		FOG_VS_BODY
+		"    return Out;\n"
+		"}\n";
+
+	// Fixed-function stage 0: COLOROP/ALPHAOP = SELECTARG1(TEXTURE).
+	const char c_achTexturePixelProgram[] =
+		"sampler2D g_kSampler0 : register(s0);\n"
+		"float4 main(float2 vTexCoord : TEXCOORD0) : COLOR0\n"
+		"{\n"
+		"    return tex2D(g_kSampler0, vTexCoord);\n"
+		"}\n";
+
+	// Fixed-function: COLOROP=MODULATE(TEXTURE,DIFFUSE), ALPHAOP=SELECTARG1(TEXTURE).
+	const char c_achModulateTexAlphaPixelProgram[] =
+		"sampler2D g_kSampler0 : register(s0);\n"
+		"float4 main(float4 vDiffuse : COLOR0, float2 vTexCoord : TEXCOORD0) : COLOR0\n"
+		"{\n"
+		"    float4 kTexel = tex2D(g_kSampler0, vTexCoord);\n"
+		"    return float4(kTexel.rgb * vDiffuse.rgb, kTexel.a);\n"
+		"}\n";
+
+	// PDT vertices with the TEXTURE0 transform applied to the UVs (COUNT2).
+	const char c_achPDTTexMatVertexProgram[] =
+		"float4 g_avWVP[4] : register(c0);\n"
+		"float4 g_avTexMat[2] : register(c4);\n"
+		FOG_VS_DECLARATIONS
+		"struct VS_INPUT { float3 vPosition : POSITION; float4 vDiffuse : COLOR0; float2 vTexCoord : TEXCOORD0; };\n"
+		"struct VS_OUTPUT { float4 vPosition : POSITION; float4 vDiffuse : COLOR0; float2 vTexCoord : TEXCOORD0; float fFog : FOG; };\n"
+		"VS_OUTPUT main(VS_INPUT In)\n"
+		"{\n"
+		"    VS_OUTPUT Out;\n"
+		"    float4 vPosition = float4(In.vPosition, 1.0f);\n"
+		"    Out.vPosition.x = dot(vPosition, g_avWVP[0]);\n"
+		"    Out.vPosition.y = dot(vPosition, g_avWVP[1]);\n"
+		"    Out.vPosition.z = dot(vPosition, g_avWVP[2]);\n"
+		"    Out.vPosition.w = dot(vPosition, g_avWVP[3]);\n"
+		"    Out.vDiffuse = In.vDiffuse;\n"
+		"    float4 vTexCoord = float4(In.vTexCoord, 1.0f, 0.0f);\n"
+		"    Out.vTexCoord.x = dot(vTexCoord, g_avTexMat[0]);\n"
+		"    Out.vTexCoord.y = dot(vTexCoord, g_avTexMat[1]);\n"
+		FOG_VS_BODY
+		"    return Out;\n"
+		"}\n";
+
+
+	// XYZ|NORMAL|TEX1 with the fixed-function directional-light formula:
+	// color = saturate(cAmbient + cDiffuse * max(0, dot(worldNormal, lightDir))).
+	const char c_achPNTLitVertexProgram[] =
+		"float4 g_avWVP[4] : register(c0);\n"
+		"float4 g_avWorld[3] : register(c4);\n"
+		"float4 g_vLightDirection : register(c8);\n"
+		"float4 g_kLitDiffuse : register(c9);\n"
+		"float4 g_kLitAmbient : register(c10);\n"
+		FOG_VS_DECLARATIONS
+		"struct VS_INPUT { float3 vPosition : POSITION; float3 vNormal : NORMAL; float2 vTexCoord : TEXCOORD0; };\n"
+		"struct VS_OUTPUT { float4 vPosition : POSITION; float4 vDiffuse : COLOR0; float2 vTexCoord : TEXCOORD0; float fFog : FOG; };\n"
+		"VS_OUTPUT main(VS_INPUT In)\n"
+		"{\n"
+		"    VS_OUTPUT Out;\n"
+		"    float4 vPosition = float4(In.vPosition, 1.0f);\n"
+		"    Out.vPosition.x = dot(vPosition, g_avWVP[0]);\n"
+		"    Out.vPosition.y = dot(vPosition, g_avWVP[1]);\n"
+		"    Out.vPosition.z = dot(vPosition, g_avWVP[2]);\n"
+		"    Out.vPosition.w = dot(vPosition, g_avWVP[3]);\n"
+		"    float4 vNormal = float4(In.vNormal, 0.0f);\n"
+		"    float3 vWorldNormal;\n"
+		"    vWorldNormal.x = dot(vNormal, g_avWorld[0]);\n"
+		"    vWorldNormal.y = dot(vNormal, g_avWorld[1]);\n"
+		"    vWorldNormal.z = dot(vNormal, g_avWorld[2]);\n"
+		"    float fDot = max(0.0f, dot(vWorldNormal, g_vLightDirection.xyz));\n"
+		"    Out.vDiffuse = saturate(g_kLitAmbient + g_kLitDiffuse * fDot);\n"
+		"    Out.vTexCoord = In.vTexCoord;\n"
+		FOG_VS_BODY
+		"    return Out;\n"
+		"}\n";
+
+	// XYZ|NORMAL|TEX1 with the fixed-function spot + point vertex lighting used
+	// by the character-preview screens (grp.SetOmniLight): per light,
+	// atten = 1/(a0 + a1*d + a2*d*d) inside Range, spot factor is the linear
+	// theta/phi cone ramp (Falloff = 1), ambient and diffuse both scaled by them.
+	const char c_achPNTLitOmniVertexProgram[] =
+		"float4 g_avWVP[4] : register(c0);\n"
+		"float4 g_avWorld[3] : register(c4);\n"
+		FOG_VS_DECLARATIONS
+		"float4 g_vSpotPos : register(c18);\n"       // xyz = position, w = range
+		"float4 g_vSpotDir : register(c19);\n"       // xyz = unit direction
+		"float4 g_vSpotAtten : register(c20);\n"     // xyz = a0/a1/a2, w = cos(theta/2)
+		"float4 g_kSpotDiffuse : register(c21);\n"   // rgb = light.Diffuse*mat.Diffuse, w = cos(phi/2)
+		"float4 g_kSpotAmbient : register(c22);\n"   // rgb = light.Ambient*mat.Ambient
+		"float4 g_vPointPos : register(c23);\n"      // xyz = position, w = range
+		"float4 g_vPointAtten : register(c24);\n"    // xyz = a0/a1/a2, w = enabled (0/1)
+		"float4 g_kPointDiffuse : register(c25);\n"
+		"float4 g_kPointAmbient : register(c26);\n"
+		"float4 g_kBaseColor : register(c27);\n"     // rgb = mat.Ambient*RS_AMBIENT + mat.Emissive, w = mat.Diffuse.a
+		"struct VS_INPUT { float3 vPosition : POSITION; float3 vNormal : NORMAL; float2 vTexCoord : TEXCOORD0; };\n"
+		"struct VS_OUTPUT { float4 vPosition : POSITION; float4 vDiffuse : COLOR0; float2 vTexCoord : TEXCOORD0; float fFog : FOG; };\n"
+		"VS_OUTPUT main(VS_INPUT In)\n"
+		"{\n"
+		"    VS_OUTPUT Out;\n"
+		"    float4 vPosition = float4(In.vPosition, 1.0f);\n"
+		"    Out.vPosition.x = dot(vPosition, g_avWVP[0]);\n"
+		"    Out.vPosition.y = dot(vPosition, g_avWVP[1]);\n"
+		"    Out.vPosition.z = dot(vPosition, g_avWVP[2]);\n"
+		"    Out.vPosition.w = dot(vPosition, g_avWVP[3]);\n"
+		"    float3 vWorldPos;\n"
+		"    vWorldPos.x = dot(vPosition, g_avWorld[0]);\n"
+		"    vWorldPos.y = dot(vPosition, g_avWorld[1]);\n"
+		"    vWorldPos.z = dot(vPosition, g_avWorld[2]);\n"
+		"    float4 vNormal = float4(In.vNormal, 0.0f);\n"
+		"    float3 vWorldNormal;\n"
+		"    vWorldNormal.x = dot(vNormal, g_avWorld[0]);\n"
+		"    vWorldNormal.y = dot(vNormal, g_avWorld[1]);\n"
+		"    vWorldNormal.z = dot(vNormal, g_avWorld[2]);\n"
+		"    float3 vColor = g_kBaseColor.rgb;\n"
+		"    {\n"
+		"        float3 vToLight = g_vSpotPos.xyz - vWorldPos;\n"
+		"        float fDist = length(vToLight);\n"
+		"        float3 vL = vToLight / fDist;\n"
+		"        float fAtten = 1.0f / dot(g_vSpotAtten.xyz, float3(1.0f, fDist, fDist * fDist));\n"
+		"        fAtten *= (fDist <= g_vSpotPos.w) ? 1.0f : 0.0f;\n"
+		"        float fRho = dot(g_vSpotDir.xyz, -vL);\n"
+		"        float fSpot = saturate((fRho - g_kSpotDiffuse.w) / (g_vSpotAtten.w - g_kSpotDiffuse.w));\n"
+		"        float fDot = max(0.0f, dot(vWorldNormal, vL));\n"
+		"        vColor += fAtten * fSpot * (g_kSpotAmbient.rgb + g_kSpotDiffuse.rgb * fDot);\n"
+		"    }\n"
+		"    {\n"
+		"        float3 vToLight = g_vPointPos.xyz - vWorldPos;\n"
+		"        float fDist = length(vToLight);\n"
+		"        float3 vL = vToLight / fDist;\n"
+		"        float fAtten = 1.0f / dot(g_vPointAtten.xyz, float3(1.0f, fDist, fDist * fDist));\n"
+		"        fAtten *= (fDist <= g_vPointPos.w) ? g_vPointAtten.w : 0.0f;\n"
+		"        float fDot = max(0.0f, dot(vWorldNormal, vL));\n"
+		"        vColor += fAtten * (g_kPointAmbient.rgb + g_kPointDiffuse.rgb * fDot);\n"
+		"    }\n"
+		"    Out.vDiffuse = saturate(float4(vColor, g_kBaseColor.w));\n"
+		"    Out.vTexCoord = In.vTexCoord;\n"
+		FOG_VS_BODY
+		"    return Out;\n"
+		"}\n";
+
+
+	// Lit PNT with a second texcoord: the fixed-function CAMERASPACEREFLECTIONVECTOR
+	// texgen (R = 2(E.N)N - E in camera space) through the TEXTURE1 transform.
+	const char c_achPNTLitSpecVertexProgram[] =
+		"float4 g_avWVP[4] : register(c0);\n"
+		"float4 g_avWorld[3] : register(c4);\n"
+		"float4 g_vLightDirection : register(c8);\n"
+		"float4 g_kLitDiffuse : register(c9);\n"
+		"float4 g_kLitAmbient : register(c10);\n"
+		"float4 g_avWorldView[3] : register(c11);\n"
+		"float4 g_avTexMat1[2] : register(c15);\n"
+		FOG_VS_PARAMS
+		"struct VS_INPUT { float3 vPosition : POSITION; float3 vNormal : NORMAL; float2 vTexCoord : TEXCOORD0; };\n"
+		"struct VS_OUTPUT { float4 vPosition : POSITION; float4 vDiffuse : COLOR0; float2 vTexCoord : TEXCOORD0; float2 vSpecCoord : TEXCOORD1; float fFog : FOG; };\n"
+		"VS_OUTPUT main(VS_INPUT In)\n"
+		"{\n"
+		"    VS_OUTPUT Out;\n"
+		"    float4 vPosition = float4(In.vPosition, 1.0f);\n"
+		"    Out.vPosition.x = dot(vPosition, g_avWVP[0]);\n"
+		"    Out.vPosition.y = dot(vPosition, g_avWVP[1]);\n"
+		"    Out.vPosition.z = dot(vPosition, g_avWVP[2]);\n"
+		"    Out.vPosition.w = dot(vPosition, g_avWVP[3]);\n"
+		"    float4 vNormal = float4(In.vNormal, 0.0f);\n"
+		"    float3 vWorldNormal;\n"
+		"    vWorldNormal.x = dot(vNormal, g_avWorld[0]);\n"
+		"    vWorldNormal.y = dot(vNormal, g_avWorld[1]);\n"
+		"    vWorldNormal.z = dot(vNormal, g_avWorld[2]);\n"
+		"    float fDot = max(0.0f, dot(vWorldNormal, g_vLightDirection.xyz));\n"
+		"    Out.vDiffuse = saturate(g_kLitAmbient + g_kLitDiffuse * fDot);\n"
+		"    Out.vTexCoord = In.vTexCoord;\n"
+		"    float3 vCamPos;\n"
+		"    vCamPos.x = dot(vPosition, g_avWorldView[0]);\n"
+		"    vCamPos.y = dot(vPosition, g_avWorldView[1]);\n"
+		"    vCamPos.z = dot(vPosition, g_avWorldView[2]);\n"
+		"    float3 vCamNormal;\n"
+		"    vCamNormal.x = dot(vNormal, g_avWorldView[0]);\n"
+		"    vCamNormal.y = dot(vNormal, g_avWorldView[1]);\n"
+		"    vCamNormal.z = dot(vNormal, g_avWorldView[2]);\n"
+		"    float3 vEye = normalize(vCamPos);\n"
+		"    float3 vUnitNormal = normalize(vCamNormal);\n"
+		"    float4 vReflect = float4(2.0f * dot(vEye, vUnitNormal) * vUnitNormal - vEye, 1.0f);\n"
+		"    Out.vSpecCoord.x = dot(vReflect, g_avTexMat1[0]);\n"
+		"    Out.vSpecCoord.y = dot(vReflect, g_avTexMat1[1]);\n"
+		"    float fFogDist = lerp(vCamPos.z, length(vCamPos), g_vFogParams2.y);\n"
+		"    Out.fFog = saturate(fFogDist * g_vFogParams.x + g_vFogParams.y) * g_vFogParams.z\n"
+		"             + exp2(-fFogDist * g_vFogParams2.x) * g_vFogParams.w;\n"
+		"    return Out;\n"
+		"}\n";
+
+	// Granny specular: stage0 MODULATE(tex, lit) with alpha = tex.a * TFACTOR.a,
+	// stage1 MODULATEALPHA_ADDCOLOR(current, envmap), alpha = current.
+	const char c_achLitSpecPixelProgram[] =
+		"sampler2D g_kSampler0 : register(s0);\n"
+		"sampler2D g_kSampler1 : register(s1);\n"
+		"float4 g_kTFactor : register(c0);\n"
+		"float4 main(float4 vDiffuse : COLOR0, float2 vTexCoord : TEXCOORD0, float2 vSpecCoord : TEXCOORD1) : COLOR0\n"
+		"{\n"
+		"    float4 kTexel = tex2D(g_kSampler0, vTexCoord);\n"
+		"    float3 vColor = kTexel.rgb * vDiffuse.rgb;\n"
+		"    float fAlpha = kTexel.a * g_kTFactor.a;\n"
+		"    float3 vEnv = tex2D(g_kSampler1, vSpecCoord).rgb;\n"
+		"    return float4(vColor + fAlpha * vEnv, fAlpha);\n"
+		"}\n";
+
+
+	// XYZ|NORMAL|TEX1|TEX2 through WVP, both UV sets passed through (dungeon).
+	const char c_achPNT2VertexProgram[] =
+		"float4 g_avWVP[4] : register(c0);\n"
+		FOG_VS_DECLARATIONS
+		"struct VS_INPUT { float3 vPosition : POSITION; float2 vTexCoord : TEXCOORD0; float2 vLightCoord : TEXCOORD1; };\n"
+		"struct VS_OUTPUT { float4 vPosition : POSITION; float2 vTexCoord : TEXCOORD0; float2 vLightCoord : TEXCOORD1; float fFog : FOG; };\n"
+		"VS_OUTPUT main(VS_INPUT In)\n"
+		"{\n"
+		"    VS_OUTPUT Out;\n"
+		"    float4 vPosition = float4(In.vPosition, 1.0f);\n"
+		"    Out.vPosition.x = dot(vPosition, g_avWVP[0]);\n"
+		"    Out.vPosition.y = dot(vPosition, g_avWVP[1]);\n"
+		"    Out.vPosition.z = dot(vPosition, g_avWVP[2]);\n"
+		"    Out.vPosition.w = dot(vPosition, g_avWVP[3]);\n"
+		"    Out.vTexCoord = In.vTexCoord;\n"
+		"    Out.vLightCoord = In.vLightCoord;\n"
+		FOG_VS_BODY
+		"    return Out;\n"
+		"}\n";
+
+	// Dungeon cascade: stage0 SELECTARG1(TEXTURE), stage1 MODULATE(TEXTURE, CURRENT).
+	const char c_achLightmapPixelProgram[] =
+		"sampler2D g_kSampler0 : register(s0);\n"
+		"sampler2D g_kSampler1 : register(s1);\n"
+		"float4 main(float2 vTexCoord : TEXCOORD0, float2 vLightCoord : TEXCOORD1) : COLOR0\n"
+		"{\n"
+		"    return tex2D(g_kSampler0, vTexCoord) * tex2D(g_kSampler1, vLightCoord);\n"
+		"}\n";
+
+
+	// Lit PNT with the fixed-function CAMERASPACEPOSITION texgen on TEXCOORD1
+	// (character-shadow projection through the TEXTURE1 transform).
+	const char c_achPNTLitRecvVertexProgram[] =
+		"float4 g_avWVP[4] : register(c0);\n"
+		"float4 g_avWorld[3] : register(c4);\n"
+		"float4 g_vLightDirection : register(c8);\n"
+		"float4 g_kLitDiffuse : register(c9);\n"
+		"float4 g_kLitAmbient : register(c10);\n"
+		"float4 g_avWorldView[3] : register(c11);\n"
+		"float4 g_avTexMat1[2] : register(c15);\n"
+		FOG_VS_PARAMS
+		"struct VS_INPUT { float3 vPosition : POSITION; float3 vNormal : NORMAL; float2 vTexCoord : TEXCOORD0; };\n"
+		"struct VS_OUTPUT { float4 vPosition : POSITION; float4 vDiffuse : COLOR0; float2 vTexCoord : TEXCOORD0; float2 vShadowCoord : TEXCOORD1; float fFog : FOG; };\n"
+		"VS_OUTPUT main(VS_INPUT In)\n"
+		"{\n"
+		"    VS_OUTPUT Out;\n"
+		"    float4 vPosition = float4(In.vPosition, 1.0f);\n"
+		"    Out.vPosition.x = dot(vPosition, g_avWVP[0]);\n"
+		"    Out.vPosition.y = dot(vPosition, g_avWVP[1]);\n"
+		"    Out.vPosition.z = dot(vPosition, g_avWVP[2]);\n"
+		"    Out.vPosition.w = dot(vPosition, g_avWVP[3]);\n"
+		"    float4 vNormal = float4(In.vNormal, 0.0f);\n"
+		"    float3 vWorldNormal;\n"
+		"    vWorldNormal.x = dot(vNormal, g_avWorld[0]);\n"
+		"    vWorldNormal.y = dot(vNormal, g_avWorld[1]);\n"
+		"    vWorldNormal.z = dot(vNormal, g_avWorld[2]);\n"
+		"    float fDot = max(0.0f, dot(vWorldNormal, g_vLightDirection.xyz));\n"
+		"    Out.vDiffuse = saturate(g_kLitAmbient + g_kLitDiffuse * fDot);\n"
+		"    Out.vTexCoord = In.vTexCoord;\n"
+		"    float4 vCamPos;\n"
+		"    vCamPos.x = dot(vPosition, g_avWorldView[0]);\n"
+		"    vCamPos.y = dot(vPosition, g_avWorldView[1]);\n"
+		"    vCamPos.z = dot(vPosition, g_avWorldView[2]);\n"
+		"    vCamPos.w = 1.0f;\n"
+		"    Out.vShadowCoord.x = dot(vCamPos, g_avTexMat1[0]);\n"
+		"    Out.vShadowCoord.y = dot(vCamPos, g_avTexMat1[1]);\n"
+		"    float fFogDist = lerp(vCamPos.z, length(vCamPos.xyz), g_vFogParams2.y);\n"
+		"    Out.fFog = saturate(fFogDist * g_vFogParams.x + g_vFogParams.y) * g_vFogParams.z\n"
+		"             + exp2(-fFogDist * g_vFogParams2.x) * g_vFogParams.w;\n"
+		"    return Out;\n"
+		"}\n";
+
+	// Shadow receiver: stage0 MODULATE(tex, lit), stage1 MODULATE(shadow, current).
+	const char c_achLitShadowPixelProgram[] =
+		"sampler2D g_kSampler0 : register(s0);\n"
+		"sampler2D g_kSampler1 : register(s1);\n"
+		"float4 main(float4 vDiffuse : COLOR0, float2 vTexCoord : TEXCOORD0, float2 vShadowCoord : TEXCOORD1) : COLOR0\n"
+		"{\n"
+		"    float3 vColor = tex2D(g_kSampler0, vTexCoord).rgb * vDiffuse.rgb;\n"
+		"    vColor *= tex2D(g_kSampler1, vShadowCoord).rgb;\n"
+		"    return float4(vColor, 1.0f);\n"
+		"}\n";
+
+	// XYZ|NORMAL|TEX1|TEX2 with the character-shadow projection on TEXCOORD1.
+	// Position goes through the same WVP dot sequence as PNT2VertexProgram so
+	// both dungeon-block passes rasterize bit-identical depths.
+	const char c_achPNT2RecvVertexProgram[] =
+		"float4 g_avWVP[4] : register(c0);\n"
+		"float4 g_avWorldView[3] : register(c11);\n"
+		"float4 g_avTexMat1[2] : register(c15);\n"
+		FOG_VS_PARAMS
+		"struct VS_INPUT { float3 vPosition : POSITION; };\n"
+		"struct VS_OUTPUT { float4 vPosition : POSITION; float2 vShadowCoord : TEXCOORD1; float fFog : FOG; };\n"
+		"VS_OUTPUT main(VS_INPUT In)\n"
+		"{\n"
+		"    VS_OUTPUT Out;\n"
+		"    float4 vPosition = float4(In.vPosition, 1.0f);\n"
+		"    Out.vPosition.x = dot(vPosition, g_avWVP[0]);\n"
+		"    Out.vPosition.y = dot(vPosition, g_avWVP[1]);\n"
+		"    Out.vPosition.z = dot(vPosition, g_avWVP[2]);\n"
+		"    Out.vPosition.w = dot(vPosition, g_avWVP[3]);\n"
+		"    float4 vCamPos;\n"
+		"    vCamPos.x = dot(vPosition, g_avWorldView[0]);\n"
+		"    vCamPos.y = dot(vPosition, g_avWorldView[1]);\n"
+		"    vCamPos.z = dot(vPosition, g_avWorldView[2]);\n"
+		"    vCamPos.w = 1.0f;\n"
+		"    Out.vShadowCoord.x = dot(vCamPos, g_avTexMat1[0]);\n"
+		"    Out.vShadowCoord.y = dot(vCamPos, g_avTexMat1[1]);\n"
+		"    float fFogDist = lerp(vCamPos.z, length(vCamPos.xyz), g_vFogParams2.y);\n"
+		"    Out.fFog = saturate(fFogDist * g_vFogParams.x + g_vFogParams.y) * g_vFogParams.z\n"
+		"             + exp2(-fFogDist * g_vFogParams2.x) * g_vFogParams.w;\n"
+		"    return Out;\n"
+		"}\n";
+
+	// Dungeon-block shadow receiver: stage0 SELECTARG1(TFACTOR), stage1
+	// MODULATE(shadow, current); the ZERO/SRCCOLOR blend applies it to the scene.
+	const char c_achTFactorShadowPixelProgram[] =
+		"sampler2D g_kSampler1 : register(s1);\n"
+		"float4 g_vTFactor : register(c0);\n"
+		"float4 main(float2 vShadowCoord : TEXCOORD1) : COLOR0\n"
+		"{\n"
+		"    return float4(g_vTFactor.rgb * tex2D(g_kSampler1, vShadowCoord).rgb, 1.0f);\n"
+		"}\n";
+
+	// Fixed-function D3DTOP_MODULATEINVALPHA_ADDCOLOR(TEXTURE, DIFFUSE), alpha = texture.
+	const char c_achInvAlphaAddPixelProgram[] =
+		"sampler2D g_kSampler0 : register(s0);\n"
+		"float4 main(float4 vDiffuse : COLOR0, float2 vTexCoord : TEXCOORD0) : COLOR0\n"
+		"{\n"
+		"    float4 kTexel = tex2D(g_kSampler0, vTexCoord);\n"
+		"    return float4(kTexel.rgb + vDiffuse.rgb * (1.0f - kTexel.a), kTexel.a);\n"
+		"}\n";
+
+	// Effect combiners: COLOROP(ARG1=TFACTOR, ARG2=TEXTURE), ALPHAOP = MODULATE.
+	const char c_achTFactorModulatePixelProgram[] =
+		"sampler2D g_kSampler0 : register(s0);\n"
+		"float4 g_kTFactor : register(c0);\n"
+		"float4 main(float2 vTexCoord : TEXCOORD0) : COLOR0\n"
+		"{\n"
+		"    float4 kTexel = tex2D(g_kSampler0, vTexCoord);\n"
+		"    return float4(kTexel.rgb * g_kTFactor.rgb, kTexel.a * g_kTFactor.a);\n"
+		"}\n";
+	const char c_achTFactorAddPixelProgram[] =
+		"sampler2D g_kSampler0 : register(s0);\n"
+		"float4 g_kTFactor : register(c0);\n"
+		"float4 main(float2 vTexCoord : TEXCOORD0) : COLOR0\n"
+		"{\n"
+		"    float4 kTexel = tex2D(g_kSampler0, vTexCoord);\n"
+		"    return float4(kTexel.rgb + g_kTFactor.rgb, kTexel.a * g_kTFactor.a);\n"
+		"}\n";
+	const char c_achTFactorOnlyPixelProgram[] =
+		"sampler2D g_kSampler0 : register(s0);\n"
+		"float4 g_kTFactor : register(c0);\n"
+		"float4 main(float2 vTexCoord : TEXCOORD0) : COLOR0\n"
+		"{\n"
+		"    float4 kTexel = tex2D(g_kSampler0, vTexCoord);\n"
+		"    return float4(g_kTFactor.rgb, kTexel.a * g_kTFactor.a);\n"
+		"}\n";
+	const char c_achTexTFactorAlphaPixelProgram[] =
+		"sampler2D g_kSampler0 : register(s0);\n"
+		"float4 g_kTFactor : register(c0);\n"
+		"float4 main(float2 vTexCoord : TEXCOORD0) : COLOR0\n"
+		"{\n"
+		"    float4 kTexel = tex2D(g_kSampler0, vTexCoord);\n"
+		"    return float4(kTexel.rgb, kTexel.a * g_kTFactor.a);\n"
+		"}\n";
+}
+
+CGraphicShaderPool::CGraphicShaderPool()
+	: m_bCreateFailed(false)
+	, m_lpPDTVertexShader(NULL)
+	, m_lpPTVertexShader(NULL)
+	, m_lpPDTTexMatVertexShader(NULL)
+	, m_lpPNTLitVertexShader(NULL)
+	, m_lpPNTLitSpecVertexShader(NULL)
+	, m_lpPNTLitOmniVertexShader(NULL)
+	, m_lpPNT2VertexShader(NULL)
+	, m_lpPNT2RecvVertexShader(NULL)
+	, m_lpPNTLitRecvVertexShader(NULL)
+	, m_lpModulatePixelShader(NULL)
+	, m_lpDiffusePixelShader(NULL)
+	, m_lpTexturePixelShader(NULL)
+	, m_lpModulateTexAlphaPixelShader(NULL)
+	, m_lpInvAlphaAddPixelShader(NULL)
+	, m_lpTFactorModulatePixelShader(NULL)
+	, m_lpTFactorAddPixelShader(NULL)
+	, m_lpTFactorOnlyPixelShader(NULL)
+	, m_lpTexTFactorAlphaPixelShader(NULL)
+	, m_lpLitSpecPixelShader(NULL)
+	, m_lpLightmapPixelShader(NULL)
+	, m_lpLitShadowPixelShader(NULL)
+	, m_lpTFactorShadowPixelShader(NULL)
+	, m_lpPDTDeclaration(NULL)
+	, m_lpPTDeclaration(NULL)
+	, m_lpPNTDeclaration(NULL)
+	, m_lpPNT2Declaration(NULL)
+{
+}
+
+CGraphicShaderPool::~CGraphicShaderPool()
+{
+	Destroy();
+}
+
+void CGraphicShaderPool::Destroy()
+{
+	safe_release(m_lpPDTVertexShader);
+	safe_release(m_lpPTVertexShader);
+	safe_release(m_lpPDTTexMatVertexShader);
+	safe_release(m_lpPNTLitVertexShader);
+	safe_release(m_lpPNTLitSpecVertexShader);
+	safe_release(m_lpPNTLitOmniVertexShader);
+	safe_release(m_lpPNT2VertexShader);
+	safe_release(m_lpPNT2RecvVertexShader);
+	safe_release(m_lpPNTLitRecvVertexShader);
+	safe_release(m_lpModulatePixelShader);
+	safe_release(m_lpDiffusePixelShader);
+	safe_release(m_lpTexturePixelShader);
+	safe_release(m_lpModulateTexAlphaPixelShader);
+	safe_release(m_lpInvAlphaAddPixelShader);
+	safe_release(m_lpTFactorModulatePixelShader);
+	safe_release(m_lpTFactorAddPixelShader);
+	safe_release(m_lpTFactorOnlyPixelShader);
+	safe_release(m_lpTexTFactorAlphaPixelShader);
+	safe_release(m_lpLitSpecPixelShader);
+	safe_release(m_lpLightmapPixelShader);
+	safe_release(m_lpLitShadowPixelShader);
+	safe_release(m_lpTFactorShadowPixelShader);
+	safe_release(m_lpPDTDeclaration);
+	safe_release(m_lpPTDeclaration);
+	safe_release(m_lpPNTDeclaration);
+	safe_release(m_lpPNT2Declaration);
+	m_bCreateFailed = false;
+}
+
+bool CGraphicShaderPool::__Create()
+{
+	if (m_bCreateFailed)
+		return false;
+
+	const D3DVERTEXELEMENT9 akPDTElements[] =
+	{
+		{ 0,  0, D3DDECLTYPE_FLOAT3,   D3DDECLMETHOD_DEFAULT, D3DDECLUSAGE_POSITION, 0 },
+		{ 0, 12, D3DDECLTYPE_D3DCOLOR, D3DDECLMETHOD_DEFAULT, D3DDECLUSAGE_COLOR,    0 },
+		{ 0, 16, D3DDECLTYPE_FLOAT2,   D3DDECLMETHOD_DEFAULT, D3DDECLUSAGE_TEXCOORD, 0 },
+		D3DDECL_END()
+	};
+
+	ID3DBlob* pCode = NULL;
+	ID3DBlob* pError = NULL;
+
+	if (FAILED(D3DCompile(c_achPDTVertexProgram, sizeof(c_achPDTVertexProgram) - 1, "PDTVertexProgram",
+						  NULL, NULL, "main", "vs_2_0", 0, 0, &pCode, &pError)) ||
+		FAILED(STATEMANAGER.CreateVertexShader((const DWORD*)pCode->GetBufferPointer(), &m_lpPDTVertexShader)))
+	{
+		TraceError("CGraphicShaderPool: failed to build PDT vertex shader [ %s ].",
+				   pError ? (const char*)pError->GetBufferPointer() : "unknown");
+		safe_release(pCode);
+		safe_release(pError);
+		m_bCreateFailed = true;
+		return false;
+	}
+
+	safe_release(pCode);
+	safe_release(pError);
+
+	if (FAILED(D3DCompile(c_achModulatePixelProgram, sizeof(c_achModulatePixelProgram) - 1, "ModulatePixelProgram",
+						  NULL, NULL, "main", "ps_2_0", 0, 0, &pCode, &pError)) ||
+		FAILED(STATEMANAGER.CreatePixelShader((const DWORD*)pCode->GetBufferPointer(), &m_lpModulatePixelShader)))
+	{
+		TraceError("CGraphicShaderPool: failed to build modulate pixel shader [ %s ].",
+				   pError ? (const char*)pError->GetBufferPointer() : "unknown");
+		safe_release(pCode);
+		safe_release(pError);
+		Destroy();
+		m_bCreateFailed = true;
+		return false;
+	}
+
+	safe_release(pCode);
+	safe_release(pError);
+
+	if (FAILED(D3DCompile(c_achDiffusePixelProgram, sizeof(c_achDiffusePixelProgram) - 1, "DiffusePixelProgram",
+						  NULL, NULL, "main", "ps_2_0", 0, 0, &pCode, &pError)) ||
+		FAILED(STATEMANAGER.CreatePixelShader((const DWORD*)pCode->GetBufferPointer(), &m_lpDiffusePixelShader)))
+	{
+		TraceError("CGraphicShaderPool: failed to build diffuse pixel shader [ %s ].",
+				   pError ? (const char*)pError->GetBufferPointer() : "unknown");
+		safe_release(pCode);
+		safe_release(pError);
+		Destroy();
+		m_bCreateFailed = true;
+		return false;
+	}
+
+	safe_release(pCode);
+	safe_release(pError);
+
+	if (FAILED(STATEMANAGER.CreateVertexDeclaration(akPDTElements, &m_lpPDTDeclaration)))
+	{
+		TraceError("CGraphicShaderPool: failed to create PDT vertex declaration.");
+		Destroy();
+		m_bCreateFailed = true;
+		return false;
+	}
+
+
+	const D3DVERTEXELEMENT9 akPTElements[] =
+	{
+		{ 0,  0, D3DDECLTYPE_FLOAT3, D3DDECLMETHOD_DEFAULT, D3DDECLUSAGE_POSITION, 0 },
+		{ 0, 12, D3DDECLTYPE_FLOAT2, D3DDECLMETHOD_DEFAULT, D3DDECLUSAGE_TEXCOORD, 0 },
+		D3DDECL_END()
+	};
+
+	if (FAILED(D3DCompile(c_achPTVertexProgram, sizeof(c_achPTVertexProgram) - 1, "PTVertexProgram",
+						  NULL, NULL, "main", "vs_2_0", 0, 0, &pCode, &pError)) ||
+		FAILED(STATEMANAGER.CreateVertexShader((const DWORD*)pCode->GetBufferPointer(), &m_lpPTVertexShader)))
+	{
+		TraceError("CGraphicShaderPool: failed to build PT vertex shader [ %s ].",
+				   pError ? (const char*)pError->GetBufferPointer() : "unknown");
+		safe_release(pCode);
+		safe_release(pError);
+		Destroy();
+		m_bCreateFailed = true;
+		return false;
+	}
+
+	safe_release(pCode);
+	safe_release(pError);
+
+	if (FAILED(D3DCompile(c_achTexturePixelProgram, sizeof(c_achTexturePixelProgram) - 1, "TexturePixelProgram",
+						  NULL, NULL, "main", "ps_2_0", 0, 0, &pCode, &pError)) ||
+		FAILED(STATEMANAGER.CreatePixelShader((const DWORD*)pCode->GetBufferPointer(), &m_lpTexturePixelShader)))
+	{
+		TraceError("CGraphicShaderPool: failed to build texture pixel shader [ %s ].",
+				   pError ? (const char*)pError->GetBufferPointer() : "unknown");
+		safe_release(pCode);
+		safe_release(pError);
+		Destroy();
+		m_bCreateFailed = true;
+		return false;
+	}
+
+	safe_release(pCode);
+	safe_release(pError);
+
+	if (FAILED(D3DCompile(c_achModulateTexAlphaPixelProgram, sizeof(c_achModulateTexAlphaPixelProgram) - 1, "ModulateTexAlphaPixelProgram",
+						  NULL, NULL, "main", "ps_2_0", 0, 0, &pCode, &pError)) ||
+		FAILED(STATEMANAGER.CreatePixelShader((const DWORD*)pCode->GetBufferPointer(), &m_lpModulateTexAlphaPixelShader)))
+	{
+		TraceError("CGraphicShaderPool: failed to build modulate-tex-alpha pixel shader [ %s ].",
+				   pError ? (const char*)pError->GetBufferPointer() : "unknown");
+		safe_release(pCode);
+		safe_release(pError);
+		Destroy();
+		m_bCreateFailed = true;
+		return false;
+	}
+
+	safe_release(pCode);
+	safe_release(pError);
+
+	if (FAILED(D3DCompile(c_achPDTTexMatVertexProgram, sizeof(c_achPDTTexMatVertexProgram) - 1, "PDTTexMatVertexProgram",
+						  NULL, NULL, "main", "vs_2_0", 0, 0, &pCode, &pError)) ||
+		FAILED(STATEMANAGER.CreateVertexShader((const DWORD*)pCode->GetBufferPointer(), &m_lpPDTTexMatVertexShader)))
+	{
+		TraceError("CGraphicShaderPool: failed to build PDTTexMatVertexProgram [ %s ].",
+				   pError ? (const char*)pError->GetBufferPointer() : "unknown");
+		safe_release(pCode);
+		safe_release(pError);
+		Destroy();
+		m_bCreateFailed = true;
+		return false;
+	}
+
+	safe_release(pCode);
+	safe_release(pError);
+
+	if (FAILED(D3DCompile(c_achInvAlphaAddPixelProgram, sizeof(c_achInvAlphaAddPixelProgram) - 1, "InvAlphaAddPixelProgram",
+						  NULL, NULL, "main", "ps_2_0", 0, 0, &pCode, &pError)) ||
+		FAILED(STATEMANAGER.CreatePixelShader((const DWORD*)pCode->GetBufferPointer(), &m_lpInvAlphaAddPixelShader)))
+	{
+		TraceError("CGraphicShaderPool: failed to build InvAlphaAddPixelProgram [ %s ].",
+				   pError ? (const char*)pError->GetBufferPointer() : "unknown");
+		safe_release(pCode);
+		safe_release(pError);
+		Destroy();
+		m_bCreateFailed = true;
+		return false;
+	}
+
+	safe_release(pCode);
+	safe_release(pError);
+
+	if (FAILED(D3DCompile(c_achTFactorModulatePixelProgram, sizeof(c_achTFactorModulatePixelProgram) - 1, "TFactorModulatePixelProgram",
+						  NULL, NULL, "main", "ps_2_0", 0, 0, &pCode, &pError)) ||
+		FAILED(STATEMANAGER.CreatePixelShader((const DWORD*)pCode->GetBufferPointer(), &m_lpTFactorModulatePixelShader)))
+	{
+		TraceError("CGraphicShaderPool: failed to build TFactorModulatePixelProgram [ %s ].",
+				   pError ? (const char*)pError->GetBufferPointer() : "unknown");
+		safe_release(pCode);
+		safe_release(pError);
+		Destroy();
+		m_bCreateFailed = true;
+		return false;
+	}
+
+	safe_release(pCode);
+	safe_release(pError);
+
+	if (FAILED(D3DCompile(c_achTFactorAddPixelProgram, sizeof(c_achTFactorAddPixelProgram) - 1, "TFactorAddPixelProgram",
+						  NULL, NULL, "main", "ps_2_0", 0, 0, &pCode, &pError)) ||
+		FAILED(STATEMANAGER.CreatePixelShader((const DWORD*)pCode->GetBufferPointer(), &m_lpTFactorAddPixelShader)))
+	{
+		TraceError("CGraphicShaderPool: failed to build TFactorAddPixelProgram [ %s ].",
+				   pError ? (const char*)pError->GetBufferPointer() : "unknown");
+		safe_release(pCode);
+		safe_release(pError);
+		Destroy();
+		m_bCreateFailed = true;
+		return false;
+	}
+
+	safe_release(pCode);
+	safe_release(pError);
+
+	if (FAILED(D3DCompile(c_achTFactorOnlyPixelProgram, sizeof(c_achTFactorOnlyPixelProgram) - 1, "TFactorOnlyPixelProgram",
+						  NULL, NULL, "main", "ps_2_0", 0, 0, &pCode, &pError)) ||
+		FAILED(STATEMANAGER.CreatePixelShader((const DWORD*)pCode->GetBufferPointer(), &m_lpTFactorOnlyPixelShader)))
+	{
+		TraceError("CGraphicShaderPool: failed to build TFactorOnlyPixelProgram [ %s ].",
+				   pError ? (const char*)pError->GetBufferPointer() : "unknown");
+		safe_release(pCode);
+		safe_release(pError);
+		Destroy();
+		m_bCreateFailed = true;
+		return false;
+	}
+
+	safe_release(pCode);
+	safe_release(pError);
+
+	if (FAILED(D3DCompile(c_achTexTFactorAlphaPixelProgram, sizeof(c_achTexTFactorAlphaPixelProgram) - 1, "TexTFactorAlphaPixelProgram",
+						  NULL, NULL, "main", "ps_2_0", 0, 0, &pCode, &pError)) ||
+		FAILED(STATEMANAGER.CreatePixelShader((const DWORD*)pCode->GetBufferPointer(), &m_lpTexTFactorAlphaPixelShader)))
+	{
+		TraceError("CGraphicShaderPool: failed to build TexTFactorAlphaPixelProgram [ %s ].",
+				   pError ? (const char*)pError->GetBufferPointer() : "unknown");
+		safe_release(pCode);
+		safe_release(pError);
+		Destroy();
+		m_bCreateFailed = true;
+		return false;
+	}
+
+	safe_release(pCode);
+	safe_release(pError);
+
+	if (FAILED(STATEMANAGER.CreateVertexDeclaration(akPTElements, &m_lpPTDeclaration)))
+	{
+		TraceError("CGraphicShaderPool: failed to create PT vertex declaration.");
+		Destroy();
+		m_bCreateFailed = true;
+		return false;
+	}
+
+
+	const D3DVERTEXELEMENT9 akPNTElements[] =
+	{
+		{ 0,  0, D3DDECLTYPE_FLOAT3, D3DDECLMETHOD_DEFAULT, D3DDECLUSAGE_POSITION, 0 },
+		{ 0, 12, D3DDECLTYPE_FLOAT3, D3DDECLMETHOD_DEFAULT, D3DDECLUSAGE_NORMAL,   0 },
+		{ 0, 24, D3DDECLTYPE_FLOAT2, D3DDECLMETHOD_DEFAULT, D3DDECLUSAGE_TEXCOORD, 0 },
+		D3DDECL_END()
+	};
+
+	if (FAILED(D3DCompile(c_achPNTLitVertexProgram, sizeof(c_achPNTLitVertexProgram) - 1, "PNTLitVertexProgram",
+						  NULL, NULL, "main", "vs_2_0", 0, 0, &pCode, &pError)) ||
+		FAILED(STATEMANAGER.CreateVertexShader((const DWORD*)pCode->GetBufferPointer(), &m_lpPNTLitVertexShader)))
+	{
+		TraceError("CGraphicShaderPool: failed to build PNT lit vertex shader [ %s ].",
+				   pError ? (const char*)pError->GetBufferPointer() : "unknown");
+		safe_release(pCode);
+		safe_release(pError);
+		Destroy();
+		m_bCreateFailed = true;
+		return false;
+	}
+
+	safe_release(pCode);
+	safe_release(pError);
+
+	if (FAILED(D3DCompile(c_achPNTLitSpecVertexProgram, sizeof(c_achPNTLitSpecVertexProgram) - 1, "PNTLitSpecVertexProgram",
+						  NULL, NULL, "main", "vs_2_0", 0, 0, &pCode, &pError)) ||
+		FAILED(STATEMANAGER.CreateVertexShader((const DWORD*)pCode->GetBufferPointer(), &m_lpPNTLitSpecVertexShader)))
+	{
+		TraceError("CGraphicShaderPool: failed to build PNTLitSpecVertexProgram [ %s ].",
+				   pError ? (const char*)pError->GetBufferPointer() : "unknown");
+		safe_release(pCode);
+		safe_release(pError);
+		Destroy();
+		m_bCreateFailed = true;
+		return false;
+	}
+
+	safe_release(pCode);
+	safe_release(pError);
+
+	if (FAILED(D3DCompile(c_achPNTLitOmniVertexProgram, sizeof(c_achPNTLitOmniVertexProgram) - 1, "PNTLitOmniVertexProgram",
+						  NULL, NULL, "main", "vs_2_0", 0, 0, &pCode, &pError)) ||
+		FAILED(STATEMANAGER.CreateVertexShader((const DWORD*)pCode->GetBufferPointer(), &m_lpPNTLitOmniVertexShader)))
+	{
+		TraceError("CGraphicShaderPool: failed to build PNTLitOmniVertexProgram [ %s ].",
+				   pError ? (const char*)pError->GetBufferPointer() : "unknown");
+		safe_release(pCode);
+		safe_release(pError);
+		Destroy();
+		m_bCreateFailed = true;
+		return false;
+	}
+
+	safe_release(pCode);
+	safe_release(pError);
+
+	if (FAILED(D3DCompile(c_achLitSpecPixelProgram, sizeof(c_achLitSpecPixelProgram) - 1, "LitSpecPixelProgram",
+						  NULL, NULL, "main", "ps_2_0", 0, 0, &pCode, &pError)) ||
+		FAILED(STATEMANAGER.CreatePixelShader((const DWORD*)pCode->GetBufferPointer(), &m_lpLitSpecPixelShader)))
+	{
+		TraceError("CGraphicShaderPool: failed to build LitSpecPixelProgram [ %s ].",
+				   pError ? (const char*)pError->GetBufferPointer() : "unknown");
+		safe_release(pCode);
+		safe_release(pError);
+		Destroy();
+		m_bCreateFailed = true;
+		return false;
+	}
+
+	safe_release(pCode);
+	safe_release(pError);
+
+	if (FAILED(D3DCompile(c_achPNT2VertexProgram, sizeof(c_achPNT2VertexProgram) - 1, "PNT2VertexProgram",
+						  NULL, NULL, "main", "vs_2_0", 0, 0, &pCode, &pError)) ||
+		FAILED(STATEMANAGER.CreateVertexShader((const DWORD*)pCode->GetBufferPointer(), &m_lpPNT2VertexShader)))
+	{
+		TraceError("CGraphicShaderPool: failed to build PNT2VertexProgram [ %s ].",
+				   pError ? (const char*)pError->GetBufferPointer() : "unknown");
+		safe_release(pCode);
+		safe_release(pError);
+		Destroy();
+		m_bCreateFailed = true;
+		return false;
+	}
+
+	safe_release(pCode);
+	safe_release(pError);
+
+	if (FAILED(D3DCompile(c_achLightmapPixelProgram, sizeof(c_achLightmapPixelProgram) - 1, "LightmapPixelProgram",
+						  NULL, NULL, "main", "ps_2_0", 0, 0, &pCode, &pError)) ||
+		FAILED(STATEMANAGER.CreatePixelShader((const DWORD*)pCode->GetBufferPointer(), &m_lpLightmapPixelShader)))
+	{
+		TraceError("CGraphicShaderPool: failed to build LightmapPixelProgram [ %s ].",
+				   pError ? (const char*)pError->GetBufferPointer() : "unknown");
+		safe_release(pCode);
+		safe_release(pError);
+		Destroy();
+		m_bCreateFailed = true;
+		return false;
+	}
+
+	safe_release(pCode);
+	safe_release(pError);
+
+	if (FAILED(D3DCompile(c_achPNTLitRecvVertexProgram, sizeof(c_achPNTLitRecvVertexProgram) - 1, "PNTLitRecvVertexProgram",
+						  NULL, NULL, "main", "vs_2_0", 0, 0, &pCode, &pError)) ||
+		FAILED(STATEMANAGER.CreateVertexShader((const DWORD*)pCode->GetBufferPointer(), &m_lpPNTLitRecvVertexShader)))
+	{
+		TraceError("CGraphicShaderPool: failed to build PNTLitRecvVertexProgram [ %s ].",
+				   pError ? (const char*)pError->GetBufferPointer() : "unknown");
+		safe_release(pCode);
+		safe_release(pError);
+		Destroy();
+		m_bCreateFailed = true;
+		return false;
+	}
+
+	safe_release(pCode);
+	safe_release(pError);
+
+	if (FAILED(D3DCompile(c_achLitShadowPixelProgram, sizeof(c_achLitShadowPixelProgram) - 1, "LitShadowPixelProgram",
+						  NULL, NULL, "main", "ps_2_0", 0, 0, &pCode, &pError)) ||
+		FAILED(STATEMANAGER.CreatePixelShader((const DWORD*)pCode->GetBufferPointer(), &m_lpLitShadowPixelShader)))
+	{
+		TraceError("CGraphicShaderPool: failed to build LitShadowPixelProgram [ %s ].",
+				   pError ? (const char*)pError->GetBufferPointer() : "unknown");
+		safe_release(pCode);
+		safe_release(pError);
+		Destroy();
+		m_bCreateFailed = true;
+		return false;
+	}
+
+	safe_release(pCode);
+	safe_release(pError);
+
+	if (FAILED(D3DCompile(c_achPNT2RecvVertexProgram, sizeof(c_achPNT2RecvVertexProgram) - 1, "PNT2RecvVertexProgram",
+						  NULL, NULL, "main", "vs_2_0", 0, 0, &pCode, &pError)) ||
+		FAILED(STATEMANAGER.CreateVertexShader((const DWORD*)pCode->GetBufferPointer(), &m_lpPNT2RecvVertexShader)))
+	{
+		TraceError("CGraphicShaderPool: failed to build PNT2RecvVertexProgram [ %s ].",
+				   pError ? (const char*)pError->GetBufferPointer() : "unknown");
+		safe_release(pCode);
+		safe_release(pError);
+		Destroy();
+		m_bCreateFailed = true;
+		return false;
+	}
+
+	safe_release(pCode);
+	safe_release(pError);
+
+	if (FAILED(D3DCompile(c_achTFactorShadowPixelProgram, sizeof(c_achTFactorShadowPixelProgram) - 1, "TFactorShadowPixelProgram",
+						  NULL, NULL, "main", "ps_2_0", 0, 0, &pCode, &pError)) ||
+		FAILED(STATEMANAGER.CreatePixelShader((const DWORD*)pCode->GetBufferPointer(), &m_lpTFactorShadowPixelShader)))
+	{
+		TraceError("CGraphicShaderPool: failed to build TFactorShadowPixelProgram [ %s ].",
+				   pError ? (const char*)pError->GetBufferPointer() : "unknown");
+		safe_release(pCode);
+		safe_release(pError);
+		Destroy();
+		m_bCreateFailed = true;
+		return false;
+	}
+
+	safe_release(pCode);
+	safe_release(pError);
+
+	const D3DVERTEXELEMENT9 akPNT2Elements[] =
+	{
+		{ 0,  0, D3DDECLTYPE_FLOAT3, D3DDECLMETHOD_DEFAULT, D3DDECLUSAGE_POSITION, 0 },
+		{ 0, 12, D3DDECLTYPE_FLOAT3, D3DDECLMETHOD_DEFAULT, D3DDECLUSAGE_NORMAL,   0 },
+		{ 0, 24, D3DDECLTYPE_FLOAT2, D3DDECLMETHOD_DEFAULT, D3DDECLUSAGE_TEXCOORD, 0 },
+		{ 0, 32, D3DDECLTYPE_FLOAT2, D3DDECLMETHOD_DEFAULT, D3DDECLUSAGE_TEXCOORD, 1 },
+		D3DDECL_END()
+	};
+
+	if (FAILED(STATEMANAGER.CreateVertexDeclaration(akPNT2Elements, &m_lpPNT2Declaration)))
+	{
+		TraceError("CGraphicShaderPool: failed to create PNT2 vertex declaration.");
+		Destroy();
+		m_bCreateFailed = true;
+		return false;
+	}
+
+	if (FAILED(STATEMANAGER.CreateVertexDeclaration(akPNTElements, &m_lpPNTDeclaration)))
+	{
+		TraceError("CGraphicShaderPool: failed to create PNT vertex declaration.");
+		Destroy();
+		m_bCreateFailed = true;
+		return false;
+	}
+
+	return true;
+}
+
+bool CGraphicShaderPool::__Bind(LPDIRECT3DVERTEXDECLARATION9 lpDeclaration, LPDIRECT3DVERTEXSHADER9 lpVertexShader, LPDIRECT3DPIXELSHADER9 lpPixelShader)
+{
+	if (!m_lpPDTDeclaration && !__Create())
+		return false;
+
+	// The caller reads its member arguments BEFORE the create above runs, so on
+	// the very first bind they are still the pre-creation NULLs; binding those
+	// would draw with no declaration/shader at all. Fall back to fixed-function
+	// for this draw - the next bind picks up the freshly created objects.
+	if (!lpDeclaration || !lpVertexShader || !lpPixelShader)
+		return false;
+
+	D3DXMATRIX matWorld, matView, matProj, matWorldView, matWVP;
+	STATEMANAGER.GetTransform(D3DTS_WORLD, &matWorld);
+	STATEMANAGER.GetTransform(D3DTS_VIEW, &matView);
+	STATEMANAGER.GetTransform(D3DTS_PROJECTION, &matProj);
+	D3DXMatrixMultiply(&matWorldView, &matWorld, &matView);
+	D3DXMatrixMultiply(&matWVP, &matWorldView, &matProj);
+	D3DXMatrixTranspose(&matWVP, &matWVP);
+	STATEMANAGER.SetVertexShaderConstant(0, &matWVP, 4);
+	D3DXMatrixTranspose(&matWorldView, &matWorldView);
+	STATEMANAGER.SetVertexShaderConstant(11, &matWorldView, 3);
+
+	// Mirror the fixed-function vertex-fog states into c28/c29: a LINEAR ramp
+	// (d * x + y, also covering the fog-off case as a constant 1) or an EXP
+	// curve, each gated by its select flag, over the plain or radial distance.
+	D3DXVECTOR4 avFogParams[2];
+	avFogParams[0] = D3DXVECTOR4(0.0f, 1.0f, 1.0f, 0.0f);
+	avFogParams[1] = D3DXVECTOR4(0.0f, 0.0f, 0.0f, 0.0f);
+	if (STATEMANAGER.GetRenderState(D3DRS_FOGENABLE))
+	{
+		const DWORD dwFogMode = STATEMANAGER.GetRenderState(D3DRS_FOGVERTEXMODE);
+		if (D3DFOG_LINEAR == dwFogMode)
+		{
+			const DWORD dwStart = STATEMANAGER.GetRenderState(D3DRS_FOGSTART);
+			const DWORD dwEnd = STATEMANAGER.GetRenderState(D3DRS_FOGEND);
+			const float fStart = *reinterpret_cast<const float*>(&dwStart);
+			const float fEnd = *reinterpret_cast<const float*>(&dwEnd);
+			// A degenerate range degrades to a hard cutoff at the end distance.
+			const float fRange = (fEnd - fStart > 0.0001f) ? (fEnd - fStart) : 0.0001f;
+			avFogParams[0].x = -1.0f / fRange;
+			avFogParams[0].y = fEnd / fRange;
+		}
+		else if (D3DFOG_EXP == dwFogMode)
+		{
+			const DWORD dwDensity = STATEMANAGER.GetRenderState(D3DRS_FOGDENSITY);
+			avFogParams[0].z = 0.0f;
+			avFogParams[0].w = 1.0f;
+			// exp(-d * density) evaluated as exp2: fold in log2(e).
+			avFogParams[1].x = *reinterpret_cast<const float*>(&dwDensity) * 1.442695f;
+		}
+		avFogParams[1].y = STATEMANAGER.GetRenderState(D3DRS_RANGEFOGENABLE) ? 1.0f : 0.0f;
+	}
+	STATEMANAGER.SetVertexShaderConstant(28, avFogParams, 2);
+
+	STATEMANAGER.SetVertexDeclaration(lpDeclaration);
+	STATEMANAGER.SetVertexShader(lpVertexShader);
+	STATEMANAGER.SetPixelShader(lpPixelShader);
+	return true;
+}
+
+bool CGraphicShaderPool::BindPDTModulate()
+{
+	return __Bind(m_lpPDTDeclaration, m_lpPDTVertexShader, m_lpModulatePixelShader);
+}
+
+bool CGraphicShaderPool::BindPDTDiffuse()
+{
+	return __Bind(m_lpPDTDeclaration, m_lpPDTVertexShader, m_lpDiffusePixelShader);
+}
+
+bool CGraphicShaderPool::BindPTTexture()
+{
+	return __Bind(m_lpPTDeclaration, m_lpPTVertexShader, m_lpTexturePixelShader);
+}
+
+bool CGraphicShaderPool::BindPDTTexture()
+{
+	return __Bind(m_lpPDTDeclaration, m_lpPDTVertexShader, m_lpTexturePixelShader);
+}
+
+bool CGraphicShaderPool::BindPDTModulateTexAlpha()
+{
+	return __Bind(m_lpPDTDeclaration, m_lpPDTVertexShader, m_lpModulateTexAlphaPixelShader);
+}
+
+bool CGraphicShaderPool::BindPDTTexMatInvAlphaAdd()
+{
+	if (!__Bind(m_lpPDTDeclaration, m_lpPDTTexMatVertexShader, m_lpInvAlphaAddPixelShader))
+		return false;
+
+	D3DXMATRIX matTexture;
+	STATEMANAGER.GetTransform(D3DTS_TEXTURE0, &matTexture);
+	D3DXMatrixTranspose(&matTexture, &matTexture);
+	STATEMANAGER.SetVertexShaderConstant(4, &matTexture, 2);
+	return true;
+}
+
+bool CGraphicShaderPool::BindPTTFactorModulate()
+{
+	return __Bind(m_lpPTDeclaration, m_lpPTVertexShader, m_lpTFactorModulatePixelShader);
+}
+
+bool CGraphicShaderPool::BindPTTFactorAdd()
+{
+	return __Bind(m_lpPTDeclaration, m_lpPTVertexShader, m_lpTFactorAddPixelShader);
+}
+
+bool CGraphicShaderPool::BindPTTFactorOnly()
+{
+	return __Bind(m_lpPTDeclaration, m_lpPTVertexShader, m_lpTFactorOnlyPixelShader);
+}
+
+bool CGraphicShaderPool::BindPTTexTFactorAlpha()
+{
+	return __Bind(m_lpPTDeclaration, m_lpPTVertexShader, m_lpTexTFactorAlphaPixelShader);
+}
+
+bool CGraphicShaderPool::BindPNTLit()
+{
+	if (!__Bind(m_lpPNTDeclaration, m_lpPNTLitVertexShader, m_lpModulatePixelShader))
+		return false;
+
+	D3DXMATRIX matWorld;
+	STATEMANAGER.GetTransform(D3DTS_WORLD, &matWorld);
+	D3DXMatrixTranspose(&matWorld, &matWorld);
+	STATEMANAGER.SetVertexShaderConstant(4, &matWorld, 3);
+	return true;
+}
+
+bool CGraphicShaderPool::BindPNTLitSpecular()
+{
+	if (!__Bind(m_lpPNTDeclaration, m_lpPNTLitSpecVertexShader, m_lpLitSpecPixelShader))
+		return false;
+
+	D3DXMATRIX matWorld, matTexture;
+	STATEMANAGER.GetTransform(D3DTS_WORLD, &matWorld);
+	D3DXMatrixTranspose(&matWorld, &matWorld);
+	STATEMANAGER.SetVertexShaderConstant(4, &matWorld, 3);
+	STATEMANAGER.GetTransform(D3DTS_TEXTURE1, &matTexture);
+	D3DXMatrixTranspose(&matTexture, &matTexture);
+	STATEMANAGER.SetVertexShaderConstant(15, &matTexture, 2);
+	return true;
+}
+
+bool CGraphicShaderPool::BindPNTLitOmni()
+{
+	if (!__Bind(m_lpPNTDeclaration, m_lpPNTLitOmniVertexShader, m_lpModulatePixelShader))
+		return false;
+
+	D3DXMATRIX matWorld;
+	STATEMANAGER.GetTransform(D3DTS_WORLD, &matWorld);
+	D3DXMatrixTranspose(&matWorld, &matWorld);
+	STATEMANAGER.SetVertexShaderConstant(4, &matWorld, 3);
+	return true;
+}
+
+bool CGraphicShaderPool::BindPNT2Lightmap()
+{
+	return __Bind(m_lpPNT2Declaration, m_lpPNT2VertexShader, m_lpLightmapPixelShader);
+}
+
+bool CGraphicShaderPool::BindPNTLitShadowReceiver()
+{
+	if (!__Bind(m_lpPNTDeclaration, m_lpPNTLitRecvVertexShader, m_lpLitShadowPixelShader))
+		return false;
+
+	D3DXMATRIX matWorld, matTexture;
+	STATEMANAGER.GetTransform(D3DTS_WORLD, &matWorld);
+	D3DXMatrixTranspose(&matWorld, &matWorld);
+	STATEMANAGER.SetVertexShaderConstant(4, &matWorld, 3);
+	STATEMANAGER.GetTransform(D3DTS_TEXTURE1, &matTexture);
+	D3DXMatrixTranspose(&matTexture, &matTexture);
+	STATEMANAGER.SetVertexShaderConstant(15, &matTexture, 2);
+	return true;
+}
+
+bool CGraphicShaderPool::BindPNT2ShadowReceiver()
+{
+	if (!__Bind(m_lpPNT2Declaration, m_lpPNT2RecvVertexShader, m_lpTFactorShadowPixelShader))
+		return false;
+
+	D3DXMATRIX matTexture;
+	STATEMANAGER.GetTransform(D3DTS_TEXTURE1, &matTexture);
+	D3DXMatrixTranspose(&matTexture, &matTexture);
+	STATEMANAGER.SetVertexShaderConstant(15, &matTexture, 2);
+	return true;
+}
+
+
+void CGraphicShaderPool::Unbind()
+{
+	STATEMANAGER.SetVertexShader(NULL);
+	STATEMANAGER.SetPixelShader(NULL);
+}

--- a/Lead-Client-Source/EterLib/GraphicShaderPool.h
+++ b/Lead-Client-Source/EterLib/GraphicShaderPool.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <d3d9.h>
+
+// Shader replacements for fixed-function draw paths (DX12 migration).
+// Compiled lazily on first bind, released on device destroy.
+class CGraphicShaderPool
+{
+	public:
+		CGraphicShaderPool();
+		~CGraphicShaderPool();
+
+		// XYZ|DIFFUSE|TEX1 vertices through WORLD*VIEW*PROJECTION,
+		// pixel = texture * diffuse (the fixed-function default cascade).
+		bool BindPDTModulate();
+		// Same vertex path, pixel = diffuse only (fixed-function NULL-texture draws).
+		bool BindPDTDiffuse();
+		// XYZ|TEX1 vertices, pixel = texture only (fixed-function SELECTARG1(TEXTURE)).
+		bool BindPTTexture();
+		// XYZ|DIFFUSE|TEX1 vertices, pixel = texture only (diffuse present but unused).
+		bool BindPDTTexture();
+		// XYZ|DIFFUSE|TEX1 vertices, rgb = texture * diffuse, alpha = texture.
+		bool BindPDTModulateTexAlpha();
+		// XYZ|DIFFUSE|TEX1 with UVs run through the TEXTURE0 transform,
+		// pixel = fixed-function MODULATEINVALPHA_ADDCOLOR (sky cloud layer).
+		bool BindPDTTexMatInvAlphaAdd();
+		// XYZ|TEX1 with TEXTUREFACTOR (c0) as the effect color; the op mirrors
+		// the data-driven COLOROP with ARG1=TFACTOR, ARG2=TEXTURE; alpha = tfactor*texture.
+		bool BindPTTFactorModulate();
+		bool BindPTTFactorAdd();
+		bool BindPTTFactorOnly();
+		bool BindPTTexTFactorAlpha();
+		// XYZ|NORMAL|TEX1 with fixed-function directional lighting evaluated in the
+		// vertex shader; lighting constants (c8-c10) are uploaded by the caller.
+		bool BindPNTLit();
+		// Lit PNT plus the sphere-map specular layer: TEXCOORD1 = camera-space
+		// reflection vector through the TEXTURE1 transform (granny specular).
+		bool BindPNTLitSpecular();
+		// PNT with the fixed-function spot + point vertex lighting used by the
+		// character-preview screens; light constants (c18-c27) uploaded by the caller.
+		bool BindPNTLitOmni();
+		// XYZ|NORMAL|TEX1|TEX2 dungeon blocks: tex0 * lightmap(tex1), no lighting.
+		bool BindPNT2Lightmap();
+		// Lit PNT with the character-shadow projection: TEXCOORD1 = camera-space
+		// position through the TEXTURE1 transform (shadow-receiver re-render pass).
+		bool BindPNTLitShadowReceiver();
+		// Dungeon-block shadow receiver: TFACTOR times the projected shadow map,
+		// position through the same WVP math as the PNT2 lightmap pass.
+		bool BindPNT2ShadowReceiver();
+		void Unbind();
+
+		void Destroy();
+
+	private:
+		bool __Create();
+		bool __Bind(LPDIRECT3DVERTEXDECLARATION9 lpDeclaration, LPDIRECT3DVERTEXSHADER9 lpVertexShader, LPDIRECT3DPIXELSHADER9 lpPixelShader);
+
+		bool m_bCreateFailed;
+		LPDIRECT3DVERTEXSHADER9			m_lpPDTVertexShader;
+		LPDIRECT3DVERTEXSHADER9			m_lpPTVertexShader;
+		LPDIRECT3DVERTEXSHADER9			m_lpPDTTexMatVertexShader;
+		LPDIRECT3DVERTEXSHADER9			m_lpPNTLitVertexShader;
+		LPDIRECT3DVERTEXSHADER9			m_lpPNTLitSpecVertexShader;
+		LPDIRECT3DVERTEXSHADER9			m_lpPNTLitOmniVertexShader;
+		LPDIRECT3DVERTEXSHADER9			m_lpPNT2VertexShader;
+		LPDIRECT3DVERTEXSHADER9			m_lpPNT2RecvVertexShader;
+		LPDIRECT3DVERTEXSHADER9			m_lpPNTLitRecvVertexShader;
+		LPDIRECT3DPIXELSHADER9			m_lpModulatePixelShader;
+		LPDIRECT3DPIXELSHADER9			m_lpDiffusePixelShader;
+		LPDIRECT3DPIXELSHADER9			m_lpTexturePixelShader;
+		LPDIRECT3DPIXELSHADER9			m_lpModulateTexAlphaPixelShader;
+		LPDIRECT3DPIXELSHADER9			m_lpInvAlphaAddPixelShader;
+		LPDIRECT3DPIXELSHADER9			m_lpTFactorModulatePixelShader;
+		LPDIRECT3DPIXELSHADER9			m_lpTFactorAddPixelShader;
+		LPDIRECT3DPIXELSHADER9			m_lpTFactorOnlyPixelShader;
+		LPDIRECT3DPIXELSHADER9			m_lpTexTFactorAlphaPixelShader;
+		LPDIRECT3DPIXELSHADER9			m_lpLitSpecPixelShader;
+		LPDIRECT3DPIXELSHADER9			m_lpLightmapPixelShader;
+		LPDIRECT3DPIXELSHADER9			m_lpLitShadowPixelShader;
+		LPDIRECT3DPIXELSHADER9			m_lpTFactorShadowPixelShader;
+		LPDIRECT3DVERTEXDECLARATION9	m_lpPDTDeclaration;
+		LPDIRECT3DVERTEXDECLARATION9	m_lpPTDeclaration;
+		LPDIRECT3DVERTEXDECLARATION9	m_lpPNTDeclaration;
+		LPDIRECT3DVERTEXDECLARATION9	m_lpPNT2Declaration;
+};

--- a/Lead-Client-Source/EterLib/GrpBase.cpp
+++ b/Lead-Client-Source/EterLib/GrpBase.cpp
@@ -4,6 +4,7 @@
 #include "GrpBase.h"
 #include "Camera.h"
 #include "StateManager.h"
+#include "GraphicShaderPool.h"
 
 void PixelPositionToD3DXVECTOR3(const D3DXVECTOR3& c_rkPPosSrc, D3DXVECTOR3* pv3Dst)
 {
@@ -34,6 +35,7 @@ D3DPRESENT_PARAMETERS	CGraphicBase::ms_d3dPresentParameter = {};
 D3DVIEWPORT9			CGraphicBase::ms_Viewport;
 
 HRESULT					CGraphicBase::ms_hLastResult = NULL;
+bool					CGraphicBase::ms_bUseShaderFFP = false;
 
 int						CGraphicBase::ms_iWidth;
 int						CGraphicBase::ms_iHeight;
@@ -185,6 +187,357 @@ bool CGraphicBase::SetPDTStream(SPDTVertexRaw* pSrcVertices, UINT uVtxCount)
 	STATEMANAGER.SetStreamSource(0, vb, sizeof(TPDTVertex));
 
 	return true;
+}
+
+static CGraphicShaderPool gs_kShaderPool;
+
+void CGraphicBase::SetUseShaderFFP(bool bEnable)
+{
+	ms_bUseShaderFFP = bEnable;
+}
+
+bool CGraphicBase::IsUseShaderFFP()
+{
+	return ms_bUseShaderFFP;
+}
+
+bool CGraphicBase::BeginPDTShader()
+{
+	if (!ms_bUseShaderFFP)
+		return false;
+
+	return gs_kShaderPool.BindPDTModulate();
+}
+
+bool CGraphicBase::BeginPDTDiffuseShader()
+{
+	if (!ms_bUseShaderFFP)
+		return false;
+
+	return gs_kShaderPool.BindPDTDiffuse();
+}
+
+bool CGraphicBase::BeginPTTextureShader()
+{
+	if (!ms_bUseShaderFFP)
+		return false;
+
+	return gs_kShaderPool.BindPTTexture();
+}
+
+bool CGraphicBase::BeginPDTTextureShader()
+{
+	if (!ms_bUseShaderFFP)
+		return false;
+
+	return gs_kShaderPool.BindPDTTexture();
+}
+
+bool CGraphicBase::BeginPDTModulateTexAlphaShader()
+{
+	if (!ms_bUseShaderFFP)
+		return false;
+
+	return gs_kShaderPool.BindPDTModulateTexAlpha();
+}
+
+bool CGraphicBase::BeginPDTCloudShader()
+{
+	if (!ms_bUseShaderFFP)
+		return false;
+
+	return gs_kShaderPool.BindPDTTexMatInvAlphaAdd();
+}
+
+bool CGraphicBase::BeginEffectShader(DWORD dwColorOp)
+{
+	if (!ms_bUseShaderFFP)
+		return false;
+
+	switch (dwColorOp)
+	{
+		case D3DTOP_MODULATE:
+			return gs_kShaderPool.BindPTTFactorModulate();
+		case D3DTOP_ADD:
+			return gs_kShaderPool.BindPTTFactorAdd();
+		case D3DTOP_SELECTARG1:
+			return gs_kShaderPool.BindPTTFactorOnly();
+		case D3DTOP_SELECTARG2:
+			return gs_kShaderPool.BindPTTexTFactorAlpha();
+		default:
+			return false;	// uncommon combiner: keep the fixed-function path
+	}
+}
+
+
+bool CGraphicBase::BeginGrannyMeshShader()
+{
+	if (!ms_bUseShaderFFP)
+		return false;
+
+	// Route by the bound stream layout first: granny characters/objects use PNT,
+	// dungeon blocks PNT2. Anything else keeps the fixed-function path.
+	DWORD dwValue;
+	const UINT uStride = STATEMANAGER.GetStreamStride(0);
+	if (sizeof(TPNT2Vertex) == uStride)
+	{
+		// Dungeon blocks are drawn twice: the lightmap pass and the character-shadow
+		// receiver re-render. Both convert together with the same WVP math so the
+		// two passes rasterize identical depths (mixed paths z-fight).
+		STATEMANAGER.GetTextureStageState(0, D3DTSS_COLOROP, &dwValue);
+		if (D3DTOP_SELECTARG1 != dwValue)
+			return false;
+		STATEMANAGER.GetTextureStageState(0, D3DTSS_COLORARG1, &dwValue);
+		const DWORD dwColorArg1 = dwValue;
+		STATEMANAGER.GetTextureStageState(1, D3DTSS_COLOROP, &dwValue);
+		if (D3DTOP_MODULATE != dwValue)
+			return false;
+		STATEMANAGER.GetTextureStageState(1, D3DTSS_COLORARG1, &dwValue);
+		if (D3DTA_TEXTURE != dwValue)
+			return false;
+		STATEMANAGER.GetTextureStageState(1, D3DTSS_COLORARG2, &dwValue);
+		if (D3DTA_CURRENT != dwValue)
+			return false;
+		LPDIRECT3DBASETEXTURE9 pkTexture;
+		STATEMANAGER.GetTexture(1, &pkTexture);
+		if (!pkTexture)
+			return false;
+		if (D3DTA_TEXTURE == dwColorArg1)
+		{
+			// Lightmap cascade: stage0 SELECTARG1(TEXTURE), stage1 MODULATE(lightmap, CURRENT).
+			STATEMANAGER.GetTexture(0, &pkTexture);
+			if (!pkTexture)
+				return false;
+			return gs_kShaderPool.BindPNT2Lightmap();
+		}
+		if (D3DTA_TFACTOR == dwColorArg1)
+		{
+			// Shadow receiver: white TFACTOR times the shadow map projected via
+			// CAMERASPACEPOSITION texgen, multiplied into the scene by the blend.
+			STATEMANAGER.GetTextureStageState(1, D3DTSS_TEXCOORDINDEX, &dwValue);
+			if (D3DTSS_TCI_CAMERASPACEPOSITION != dwValue)
+				return false;
+			return gs_kShaderPool.BindPNT2ShadowReceiver();
+		}
+		return false;
+	}
+	if (sizeof(TPNTVertex) != uStride)
+		return false;
+
+	// Only the base cascade is converted: stage 0 MODULATE(TEXTURE, DIFFUSE) for
+	// color and alpha, stage 1 disabled, a texture bound. Specular, fades and
+	// two-texture materials keep the fixed-function path for now.
+	STATEMANAGER.GetTextureStageState(0, D3DTSS_COLOROP, &dwValue);
+	if (D3DTOP_MODULATE != dwValue)
+		return false;
+	STATEMANAGER.GetTextureStageState(0, D3DTSS_COLORARG1, &dwValue);
+	if (D3DTA_TEXTURE != dwValue)
+		return false;
+	STATEMANAGER.GetTextureStageState(0, D3DTSS_COLORARG2, &dwValue);
+	if (D3DTA_DIFFUSE != dwValue)
+		return false;
+	STATEMANAGER.GetTextureStageState(0, D3DTSS_ALPHAOP, &dwValue);
+	if (D3DTOP_DISABLE == dwValue)
+	{
+		// Character-shadow receiver re-render: stage1 projects the shadow map via
+		// CAMERASPACEPOSITION texgen. Must use the same vertex path as the main
+		// pass or the two passes z-fight.
+		STATEMANAGER.GetTextureStageState(1, D3DTSS_COLOROP, &dwValue);
+		if (D3DTOP_MODULATE != dwValue)
+			return false;
+		STATEMANAGER.GetTextureStageState(1, D3DTSS_COLORARG1, &dwValue);
+		if (D3DTA_TEXTURE != dwValue)
+			return false;
+		STATEMANAGER.GetTextureStageState(1, D3DTSS_COLORARG2, &dwValue);
+		if (D3DTA_CURRENT != dwValue)
+			return false;
+		STATEMANAGER.GetTextureStageState(1, D3DTSS_TEXCOORDINDEX, &dwValue);
+		if (D3DTSS_TCI_CAMERASPACEPOSITION != dwValue)
+			return false;
+		LPDIRECT3DBASETEXTURE9 pkShadowTexture;
+		STATEMANAGER.GetTexture(0, &pkShadowTexture);
+		if (!pkShadowTexture)
+			return false;
+		STATEMANAGER.GetTexture(1, &pkShadowTexture);
+		if (!pkShadowTexture)
+			return false;
+		if (!gs_kShaderPool.BindPNTLitShadowReceiver())
+			return false;
+		__UploadGrannyLightingConstants();
+		return true;
+	}
+	if (D3DTOP_MODULATE != dwValue)
+		return false;
+	STATEMANAGER.GetTextureStageState(0, D3DTSS_ALPHAARG1, &dwValue);
+	if (D3DTA_TEXTURE != dwValue)
+		return false;
+	STATEMANAGER.GetTextureStageState(0, D3DTSS_ALPHAARG2, &dwValue);
+	const bool bSpecularAlpha = (D3DTA_TFACTOR == dwValue);
+	if (D3DTA_DIFFUSE != dwValue && !bSpecularAlpha)
+		return false;
+	STATEMANAGER.GetTextureStageState(1, D3DTSS_COLOROP, &dwValue);
+	bool bSpecular = false;
+	if (bSpecularAlpha && D3DTOP_MODULATEALPHA_ADDCOLOR == dwValue)
+	{
+		// Granny sphere-map specular: verify the full stage-1 cascade.
+		STATEMANAGER.GetTextureStageState(1, D3DTSS_COLORARG1, &dwValue);
+		if (D3DTA_CURRENT != dwValue)
+			return false;
+		STATEMANAGER.GetTextureStageState(1, D3DTSS_COLORARG2, &dwValue);
+		if (D3DTA_TEXTURE != dwValue)
+			return false;
+		STATEMANAGER.GetTextureStageState(1, D3DTSS_ALPHAOP, &dwValue);
+		if (D3DTOP_SELECTARG1 != dwValue)
+			return false;
+		STATEMANAGER.GetTextureStageState(1, D3DTSS_TEXCOORDINDEX, &dwValue);
+		if (D3DTSS_TCI_CAMERASPACEREFLECTIONVECTOR != dwValue)
+			return false;
+		LPDIRECT3DBASETEXTURE9 pEnvTexture;
+		STATEMANAGER.GetTexture(1, &pEnvTexture);
+		if (!pEnvTexture)
+			return false;
+		bSpecular = true;
+	}
+	else if (bSpecularAlpha || D3DTOP_DISABLE != dwValue)
+		return false;
+
+	LPDIRECT3DBASETEXTURE9 pTexture;
+	STATEMANAGER.GetTexture(0, &pTexture);
+	if (!pTexture)
+		return false;
+
+	// The character-preview screens light with a spot + point pair instead of
+	// the world's directional light (grp.SetOmniLight); route them to the omni
+	// program. Any other light type keeps the fixed-function path.
+	if (STATEMANAGER.GetRenderState(D3DRS_LIGHTING) && STATEMANAGER.GetLightEnable(0))
+	{
+		D3DLIGHT9 kLight;
+		STATEMANAGER.GetLight(0, &kLight);
+		if (D3DLIGHT_SPOT == kLight.Type)
+		{
+			if (bSpecular)
+				return false;
+			if (!gs_kShaderPool.BindPNTLitOmni())
+				return false;
+			__UploadOmniLightingConstants();
+			return true;
+		}
+		if (D3DLIGHT_DIRECTIONAL != kLight.Type)
+			return false;
+	}
+
+	if (bSpecular)
+	{
+		if (!gs_kShaderPool.BindPNTLitSpecular())
+			return false;
+	}
+	else if (!gs_kShaderPool.BindPNTLit())
+		return false;
+
+	__UploadGrannyLightingConstants();
+	return true;
+}
+
+void CGraphicBase::__UploadGrannyLightingConstants()
+{
+	// Fixed-function directional light: color = saturate(cAmbient + cDiffuse * max(0, N.L)).
+	D3DXVECTOR4 avConstants[3];
+	if (STATEMANAGER.GetRenderState(D3DRS_LIGHTING) && STATEMANAGER.GetLightEnable(0))
+	{
+		D3DLIGHT9 kLight;
+		STATEMANAGER.GetLight(0, &kLight);
+		D3DMATERIAL9 kMaterial;
+		STATEMANAGER.GetMaterial(&kMaterial);
+		const DWORD dwAmbient = STATEMANAGER.GetRenderState(D3DRS_AMBIENT);
+		const float c_fInv255 = 1.0f / 255.0f;
+		const float fAmbientR = ((dwAmbient >> 16) & 0xff) * c_fInv255 + kLight.Ambient.r;
+		const float fAmbientG = ((dwAmbient >> 8) & 0xff) * c_fInv255 + kLight.Ambient.g;
+		const float fAmbientB = (dwAmbient & 0xff) * c_fInv255 + kLight.Ambient.b;
+		const float fAmbientA = ((dwAmbient >> 24) & 0xff) * c_fInv255 + kLight.Ambient.a;
+
+		avConstants[0] = D3DXVECTOR4(-kLight.Direction.x, -kLight.Direction.y, -kLight.Direction.z, 0.0f);
+		avConstants[1] = D3DXVECTOR4(kMaterial.Diffuse.r * kLight.Diffuse.r,
+									 kMaterial.Diffuse.g * kLight.Diffuse.g,
+									 kMaterial.Diffuse.b * kLight.Diffuse.b,
+									 kMaterial.Diffuse.a * kLight.Diffuse.a);
+		avConstants[2] = D3DXVECTOR4(kMaterial.Ambient.r * fAmbientR + kMaterial.Emissive.r,
+									 kMaterial.Ambient.g * fAmbientG + kMaterial.Emissive.g,
+									 kMaterial.Ambient.b * fAmbientB + kMaterial.Emissive.b,
+									 kMaterial.Ambient.a * fAmbientA + kMaterial.Emissive.a);
+	}
+	else
+	{
+		// Lighting off: fixed function feeds an opaque white vertex color.
+		avConstants[0] = D3DXVECTOR4(0.0f, 0.0f, 0.0f, 0.0f);
+		avConstants[1] = D3DXVECTOR4(0.0f, 0.0f, 0.0f, 0.0f);
+		avConstants[2] = D3DXVECTOR4(1.0f, 1.0f, 1.0f, 1.0f);
+	}
+	STATEMANAGER.SetVertexShaderConstant(8, avConstants, 3);
+}
+
+void CGraphicBase::__UploadOmniLightingConstants()
+{
+	// Fixed-function spot (light 0) + point (light 1) vertex lighting, as set up
+	// by the character-preview screens. Products are premultiplied per light;
+	// the shader applies range-clamped attenuation and the linear cone ramp.
+	D3DLIGHT9 kSpot;
+	STATEMANAGER.GetLight(0, &kSpot);
+	D3DMATERIAL9 kMaterial;
+	STATEMANAGER.GetMaterial(&kMaterial);
+	const DWORD dwAmbient = STATEMANAGER.GetRenderState(D3DRS_AMBIENT);
+	const float c_fInv255 = 1.0f / 255.0f;
+	const float fGlobalR = ((dwAmbient >> 16) & 0xff) * c_fInv255;
+	const float fGlobalG = ((dwAmbient >> 8) & 0xff) * c_fInv255;
+	const float fGlobalB = (dwAmbient & 0xff) * c_fInv255;
+
+	D3DXVECTOR3 v3SpotDir(kSpot.Direction.x, kSpot.Direction.y, kSpot.Direction.z);
+	D3DXVec3Normalize(&v3SpotDir, &v3SpotDir);
+
+	// A degenerate cone (Theta == Phi) would make the shader's linear ramp 0/0;
+	// keep the denominator positive so it degrades to the FFP hard cutoff.
+	const float fCosTheta = cosf(kSpot.Theta * 0.5f);
+	float fCosPhi = cosf(kSpot.Phi * 0.5f);
+	if (fCosTheta - fCosPhi < 0.0001f)
+		fCosPhi = fCosTheta - 0.0001f;
+
+	D3DXVECTOR4 avConstants[10];
+	avConstants[0] = D3DXVECTOR4(kSpot.Position.x, kSpot.Position.y, kSpot.Position.z, kSpot.Range);
+	avConstants[1] = D3DXVECTOR4(v3SpotDir.x, v3SpotDir.y, v3SpotDir.z, 0.0f);
+	avConstants[2] = D3DXVECTOR4(kSpot.Attenuation0, kSpot.Attenuation1, kSpot.Attenuation2, fCosTheta);
+	avConstants[3] = D3DXVECTOR4(kMaterial.Diffuse.r * kSpot.Diffuse.r,
+								 kMaterial.Diffuse.g * kSpot.Diffuse.g,
+								 kMaterial.Diffuse.b * kSpot.Diffuse.b,
+								 fCosPhi);
+	avConstants[4] = D3DXVECTOR4(kMaterial.Ambient.r * kSpot.Ambient.r,
+								 kMaterial.Ambient.g * kSpot.Ambient.g,
+								 kMaterial.Ambient.b * kSpot.Ambient.b, 0.0f);
+
+	D3DLIGHT9 kPoint;
+	STATEMANAGER.GetLight(1, &kPoint);
+	const float fPointOn = STATEMANAGER.GetLightEnable(1) ? 1.0f : 0.0f;
+	avConstants[5] = D3DXVECTOR4(kPoint.Position.x, kPoint.Position.y, kPoint.Position.z, kPoint.Range);
+	avConstants[6] = D3DXVECTOR4(kPoint.Attenuation0, kPoint.Attenuation1, kPoint.Attenuation2, fPointOn);
+	avConstants[7] = D3DXVECTOR4(kMaterial.Diffuse.r * kPoint.Diffuse.r,
+								 kMaterial.Diffuse.g * kPoint.Diffuse.g,
+								 kMaterial.Diffuse.b * kPoint.Diffuse.b, 0.0f);
+	avConstants[8] = D3DXVECTOR4(kMaterial.Ambient.r * kPoint.Ambient.r,
+								 kMaterial.Ambient.g * kPoint.Ambient.g,
+								 kMaterial.Ambient.b * kPoint.Ambient.b, 0.0f);
+	avConstants[9] = D3DXVECTOR4(kMaterial.Ambient.r * fGlobalR + kMaterial.Emissive.r,
+								 kMaterial.Ambient.g * fGlobalG + kMaterial.Emissive.g,
+								 kMaterial.Ambient.b * fGlobalB + kMaterial.Emissive.b,
+								 kMaterial.Diffuse.a);
+	STATEMANAGER.SetVertexShaderConstant(18, avConstants, 10);
+}
+
+void CGraphicBase::EndPDTShader()
+{
+	gs_kShaderPool.Unbind();
+}
+
+void CGraphicBase::DestroyShaderPool()
+{
+	gs_kShaderPool.Destroy();
 }
 
 DWORD CGraphicBase::GetAvailableTextureMemory()

--- a/Lead-Client-Source/EterLib/GrpBase.h
+++ b/Lead-Client-Source/EterLib/GrpBase.h
@@ -216,6 +216,25 @@ class CGraphicBase
 		static void SetDefaultIndexBuffer(UINT eDefIB);
 		static bool SetPDTStream(SPDTVertexRaw* pVertices, UINT uVtxCount);
 		static bool SetPDTStream(SPDTVertex* pVertices, UINT uVtxCount);
+
+		// Fixed-function replacement shaders (DX12 migration); default off.
+		static void SetUseShaderFFP(bool bEnable);
+		static bool IsUseShaderFFP();
+		static bool BeginPDTShader();		// true = shader pipeline bound; else use the FVF path
+		static bool BeginPDTDiffuseShader();	// variant for NULL-texture draws (diffuse passthrough)
+		static bool BeginPTTextureShader();	// XYZ|TEX1 draws (texture passthrough)
+		static bool BeginPDTTextureShader();	// XYZ|DIFFUSE|TEX1 draws where FFP selects TEXTURE only
+		static bool BeginPDTModulateTexAlphaShader();	// rgb = texture*diffuse, alpha = texture
+		static bool BeginPDTCloudShader();	// scrolling-UV cloud layer (MODULATEINVALPHA_ADDCOLOR)
+		static bool BeginEffectShader(DWORD dwColorOp);	// effect COLOROP(TFACTOR, TEXTURE); false = unsupported op, use FFP
+		static bool BeginGrannyMeshShader();	// lit PNT mesh w/ base modulate cascade; false = keep FFP
+		static void EndPDTShader();		// call only after a successful Begin*Shader
+		static void DestroyShaderPool();
+
+	private:
+		static void __UploadGrannyLightingConstants();
+		static void __UploadOmniLightingConstants();
+	public:
 		
 	protected:
 		static D3DXMATRIX				ms_matIdentity;
@@ -239,6 +258,8 @@ class CGraphicBase
 
 	protected:
 		static HRESULT					ms_hLastResult;
+
+		static bool						ms_bUseShaderFFP;
 
 		static int						ms_iWidth;
 		static int						ms_iHeight;

--- a/Lead-Client-Source/EterLib/GrpDevice.cpp
+++ b/Lead-Client-Source/EterLib/GrpDevice.cpp
@@ -749,6 +749,7 @@ void CGraphicDevice::InitBackBufferCount(UINT uBackBufferCount)
 
 void CGraphicDevice::Destroy()
 {
+	DestroyShaderPool();
 	__DestroyPDTVertexBufferList();
 	__DestroyDefaultIndexBufferList();
 

--- a/Lead-Client-Source/EterLib/GrpImageInstance.cpp
+++ b/Lead-Client-Source/EterLib/GrpImageInstance.cpp
@@ -90,8 +90,16 @@ void CGraphicImageInstance::OnRender()
 
 		STATEMANAGER.SetTexture(0, pTexture->GetD3DTexture());
 		STATEMANAGER.SetTexture(1, NULL);
-		STATEMANAGER.SetFVF(D3DFVF_XYZ|D3DFVF_DIFFUSE|D3DFVF_TEX1);
-		STATEMANAGER.DrawIndexedPrimitive(D3DPT_TRIANGLELIST, 0, 4, 0, 2);	
+		if (CGraphicBase::BeginPDTShader())
+		{
+			STATEMANAGER.DrawIndexedPrimitive(D3DPT_TRIANGLELIST, 0, 4, 0, 2);
+			CGraphicBase::EndPDTShader();
+		}
+		else
+		{
+			STATEMANAGER.SetFVF(D3DFVF_XYZ|D3DFVF_DIFFUSE|D3DFVF_TEX1);
+			STATEMANAGER.DrawIndexedPrimitive(D3DPT_TRIANGLELIST, 0, 4, 0, 2);
+		}
 	}
 	//OLD: STATEMANAGER.DrawIndexedPrimitiveUP(D3DPT_TRIANGLELIST, 0, 4, 2, c_FillRectIndices, D3DFMT_INDEX16, vertices, sizeof(TPDTVertex));	
 	////////////////////////////////////////////////////////////	

--- a/Lead-Client-Source/EterLib/LensFlare.cpp
+++ b/Lead-Client-Source/EterLib/LensFlare.cpp
@@ -258,8 +258,16 @@ void CLensFlare::DrawBeforeFlare()
 	STATEMANAGER.SetTextureStageState(0, D3DTSS_ALPHAOP, D3DTOP_SELECTARG1);
 	STATEMANAGER.SetTextureStageState(0, D3DTSS_COLORARG1, D3DTA_TEXTURE);
 	
-	STATEMANAGER.SetFVF(D3DFVF_XYZ|D3DFVF_DIFFUSE|D3DFVF_TEX1);
-	STATEMANAGER.DrawPrimitiveUP(D3DPT_TRIANGLESTRIP, 2, vertices, sizeof(SVertex));
+	if (CGraphicBase::BeginPDTModulateTexAlphaShader())
+	{
+		STATEMANAGER.DrawPrimitiveUP(D3DPT_TRIANGLESTRIP, 2, vertices, sizeof(SVertex));
+		CGraphicBase::EndPDTShader();
+	}
+	else
+	{
+		STATEMANAGER.SetFVF(D3DFVF_XYZ|D3DFVF_DIFFUSE|D3DFVF_TEX1);
+		STATEMANAGER.DrawPrimitiveUP(D3DPT_TRIANGLESTRIP, 2, vertices, sizeof(SVertex));
+	}
 
 	STATEMANAGER.RestoreRenderState(D3DRS_LIGHTING);
 	STATEMANAGER.RestoreRenderState(D3DRS_ZENABLE); // glDisable(GL_DEPTH_TEST);
@@ -591,7 +599,13 @@ void CFlare::Draw(float fBrightScale, int nWidth, int nHeight, int nX, int nY)
 		vertices[3].z = 0.0f;
 		vertices[3].color = d3dColor;
 
-		STATEMANAGER.DrawPrimitiveUP(D3DPT_TRIANGLESTRIP, 2, vertices, sizeof(TVertex));
+		if (CGraphicBase::BeginPDTShader())
+		{
+			STATEMANAGER.DrawPrimitiveUP(D3DPT_TRIANGLESTRIP, 2, vertices, sizeof(TVertex));
+			CGraphicBase::EndPDTShader();
+		}
+		else
+			STATEMANAGER.DrawPrimitiveUP(D3DPT_TRIANGLESTRIP, 2, vertices, sizeof(TVertex));
 	}
 
 	STATEMANAGER.RestoreRenderState(D3DRS_DESTBLEND);

--- a/Lead-Client-Source/EterLib/StateManager.cpp
+++ b/Lead-Client-Source/EterLib/StateManager.cpp
@@ -29,6 +29,13 @@ void CStateManager::GetLight(DWORD index, D3DLIGHT9* pLight)
 	*pLight=m_kLightData.m_akD3DLight[index];
 }
 
+BOOL CStateManager::GetLightEnable(DWORD index)
+{
+	BOOL bEnable = FALSE;
+	m_lpD3DDev->GetLightEnable(index, &bEnable);
+	return bEnable;
+}
+
 HRESULT CStateManager::CreateVertexShader(CONST DWORD* pFunction, LPDIRECT3DVERTEXSHADER9* ppShader)
 {
 	return m_lpD3DDev->CreateVertexShader(pFunction, ppShader);
@@ -37,6 +44,11 @@ HRESULT CStateManager::CreateVertexShader(CONST DWORD* pFunction, LPDIRECT3DVERT
 HRESULT CStateManager::CreateVertexDeclaration(CONST D3DVERTEXELEMENT9* pVertexElements, LPDIRECT3DVERTEXDECLARATION9* ppDecl)
 {
 	return m_lpD3DDev->CreateVertexDeclaration(pVertexElements, ppDecl);
+}
+
+HRESULT CStateManager::CreatePixelShader(CONST DWORD* pFunction, LPDIRECT3DPIXELSHADER9* ppShader)
+{
+	return m_lpD3DDev->CreatePixelShader(pFunction, ppShader);
 }
 
 bool CStateManager::BeginScene()
@@ -465,6 +477,20 @@ void CStateManager::RestoreRenderState(D3DRENDERSTATETYPE Type)
 
 void CStateManager::SetRenderState(D3DRENDERSTATETYPE Type, DWORD Value)
 {
+	// The shader pipeline reads TEXTUREFACTOR from pixel constant c0.
+	if (D3DRS_TEXTUREFACTOR == Type)
+	{
+		const float c_fInv255 = 1.0f / 255.0f;
+		const float afColor[4] =
+		{
+			((Value >> 16) & 0xff) * c_fInv255,
+			((Value >> 8) & 0xff) * c_fInv255,
+			(Value & 0xff) * c_fInv255,
+			((Value >> 24) & 0xff) * c_fInv255,
+		};
+		SetPixelShaderConstant(0, afColor, 1);
+	}
+
 	if (m_CurrentState.m_RenderStates[Type] == Value)
 		return;
 

--- a/Lead-Client-Source/EterLib/StateManager.cpp
+++ b/Lead-Client-Source/EterLib/StateManager.cpp
@@ -29,6 +29,16 @@ void CStateManager::GetLight(DWORD index, D3DLIGHT9* pLight)
 	*pLight=m_kLightData.m_akD3DLight[index];
 }
 
+HRESULT CStateManager::CreateVertexShader(CONST DWORD* pFunction, LPDIRECT3DVERTEXSHADER9* ppShader)
+{
+	return m_lpD3DDev->CreateVertexShader(pFunction, ppShader);
+}
+
+HRESULT CStateManager::CreateVertexDeclaration(CONST D3DVERTEXELEMENT9* pVertexElements, LPDIRECT3DVERTEXDECLARATION9* ppDecl)
+{
+	return m_lpD3DDev->CreateVertexDeclaration(pVertexElements, ppDecl);
+}
+
 bool CStateManager::BeginScene()
 {
 	m_bScene=true;

--- a/Lead-Client-Source/EterLib/StateManager.h
+++ b/Lead-Client-Source/EterLib/StateManager.h
@@ -252,12 +252,14 @@ class CStateManager : public CSingleton<CStateManager>
 		void	RestoreMaterial();
 		void	SetMaterial(const D3DMATERIAL9 * pMaterial);
 		void	GetMaterial(D3DMATERIAL9 * pMaterial);
+		BOOL	GetLightEnable(DWORD index);
 
 		void	SetLight(DWORD index, CONST D3DLIGHT9* pLight);
 		void	GetLight(DWORD index, D3DLIGHT9* pLight);
 
 		HRESULT	CreateVertexShader(CONST DWORD* pFunction, LPDIRECT3DVERTEXSHADER9* ppShader);
 		HRESULT	CreateVertexDeclaration(CONST D3DVERTEXELEMENT9* pVertexElements, LPDIRECT3DVERTEXDECLARATION9* ppDecl);
+		HRESULT	CreatePixelShader(CONST DWORD* pFunction, LPDIRECT3DPIXELSHADER9* ppShader);
 
 		// Renderstates
 		void	SaveRenderState(D3DRENDERSTATETYPE Type, DWORD dwValue);
@@ -334,6 +336,7 @@ class CStateManager : public CSingleton<CStateManager>
 		void SaveStreamSource(UINT StreamNumber, LPDIRECT3DVERTEXBUFFER9 pStreamData, UINT Stride);
 		void RestoreStreamSource(UINT StreamNumber);
 		void SetStreamSource(UINT StreamNumber, LPDIRECT3DVERTEXBUFFER9 pStreamData, UINT Stride);
+		UINT GetStreamStride(UINT StreamNumber) const { return m_CurrentState.m_StreamData[StreamNumber].m_Stride; }
 
 		void SaveIndices(LPDIRECT3DINDEXBUFFER9 pIndexData, UINT BaseVertexIndex);
 		void RestoreIndices();

--- a/Lead-Client-Source/EterLib/StateManager.h
+++ b/Lead-Client-Source/EterLib/StateManager.h
@@ -256,6 +256,9 @@ class CStateManager : public CSingleton<CStateManager>
 		void	SetLight(DWORD index, CONST D3DLIGHT9* pLight);
 		void	GetLight(DWORD index, D3DLIGHT9* pLight);
 
+		HRESULT	CreateVertexShader(CONST DWORD* pFunction, LPDIRECT3DVERTEXSHADER9* ppShader);
+		HRESULT	CreateVertexDeclaration(CONST D3DVERTEXELEMENT9* pVertexElements, LPDIRECT3DVERTEXDECLARATION9* ppDecl);
+
 		// Renderstates
 		void	SaveRenderState(D3DRENDERSTATETYPE Type, DWORD dwValue);
 		void	RestoreRenderState(D3DRENDERSTATETYPE Type);

--- a/Lead-Client-Source/GameLib/FlyTrace.cpp
+++ b/Lead-Client-Source/GameLib/FlyTrace.cpp
@@ -272,7 +272,13 @@ void CFlyTrace::Render()
 
 	for(TFlyVertexSetVector::iterator it = VSVector.begin();it!=VSVector.end();++it)
 	{
-		STATEMANAGER.DrawPrimitiveUP(D3DPT_TRIANGLESTRIP, 4, it->second.v, sizeof(TVertex));
+		if (CGraphicBase::BeginPDTDiffuseShader())
+		{
+			STATEMANAGER.DrawPrimitiveUP(D3DPT_TRIANGLESTRIP, 4, it->second.v, sizeof(TVertex));
+			CGraphicBase::EndPDTShader();
+		}
+		else
+			STATEMANAGER.DrawPrimitiveUP(D3DPT_TRIANGLESTRIP, 4, it->second.v, sizeof(TVertex));
 	}
 	STATEMANAGER.RestoreRenderState(D3DRS_DESTBLEND);
 	STATEMANAGER.RestoreRenderState(D3DRS_SRCBLEND);

--- a/Lead-Client-Source/GameLib/MapOutdoorLoad.cpp
+++ b/Lead-Client-Source/GameLib/MapOutdoorLoad.cpp
@@ -37,7 +37,7 @@ bool CMapOutdoor::Load(float x, float y, float z)
 	m_lOldReadX = -1;
 
 	// TODO: In SetRenderingDevice, you must pass the light properties from the Environment for the static light to work properly.
-	CSpeedTreeForestDirectX8::Instance().SetRenderingDevice(ms_lpd3dDevice);
+	CSpeedTreeForestDirectX8::Instance().SetRenderingDevice();
 
 	Update(x, y, z);
 

--- a/Lead-Client-Source/GameLib/WeaponTrace.cpp
+++ b/Lead-Client-Source/GameLib/WeaponTrace.cpp
@@ -326,10 +326,13 @@ void CWeaponTrace::Render()
 	STATEMANAGER.SetRenderState(D3DRS_LIGHTING, FALSE);
 	STATEMANAGER.SetTexture(0, lpTexture);
 	STATEMANAGER.SetTexture(1, NULL);
+	const bool bShaderPipeline = m_bUseTexture ? CGraphicBase::BeginPDTTextureShader() : CGraphicBase::BeginPDTDiffuseShader();
 	STATEMANAGER.DrawPrimitiveUP(D3DPT_TRIANGLESTRIP,
 								 int(m_PDTVertexVector.size() - 2),
 								 &m_PDTVertexVector[0],
 								 sizeof(TPDTVertex));
+	if (bShaderPipeline)
+		CGraphicBase::EndPDTShader();
 	
 	STATEMANAGER.SetRenderState(D3DRS_LIGHTING, TRUE);
 

--- a/Lead-Client-Source/SpeedTreeLib/SpeedTreeForestDirectX8.cpp
+++ b/Lead-Client-Source/SpeedTreeLib/SpeedTreeForestDirectX8.cpp
@@ -65,10 +65,10 @@ bool CSpeedTreeForestDirectX8::InitVertexShaders(void)
 	NANOBEGIN
 	// load the vertex shaders
 	if (!m_dwBranchVertexShader)
-		m_dwBranchVertexShader = LoadBranchShader(m_pDx);
+		m_dwBranchVertexShader = LoadBranchShader();
 
 	if (!m_pLeafVertexShaderDecl || !m_pLeafVertexShader)
-		LoadLeafShader(m_pDx, m_pLeafVertexShaderDecl, m_pLeafVertexShader);
+		LoadLeafShader(m_pLeafVertexShaderDecl, m_pLeafVertexShader);
 
 	if (m_dwBranchVertexShader && m_pLeafVertexShaderDecl && m_pLeafVertexShader)
 	{
@@ -80,10 +80,8 @@ bool CSpeedTreeForestDirectX8::InitVertexShaders(void)
 	return false;
 }
 
-bool CSpeedTreeForestDirectX8::SetRenderingDevice(LPDIRECT3DDEVICE9 lpDevice)
+bool CSpeedTreeForestDirectX8::SetRenderingDevice()
 {
-	m_pDx = lpDevice;
-
 	if (!InitVertexShaders())
 		return false;
 

--- a/Lead-Client-Source/SpeedTreeLib/SpeedTreeForestDirectX8.h
+++ b/Lead-Client-Source/SpeedTreeLib/SpeedTreeForestDirectX8.h
@@ -51,14 +51,12 @@ class CSpeedTreeForestDirectX8 : public CSpeedTreeForest, public CGraphicBase, p
 		void			UpdateCompundMatrix(const D3DXVECTOR3 & c_rEyeVec, const D3DXMATRIX & c_rmatView, const D3DXMATRIX & c_rmatProj);
 
 		void			Render(unsigned long ulRenderBitVector = Forest_RenderAll);
-		bool			SetRenderingDevice(LPDIRECT3DDEVICE9 pDevice);
+		bool			SetRenderingDevice();
 		
 	private:
 		bool			InitVertexShaders();
 		
 	private:
-		LPDIRECT3DDEVICE9		m_pDx;							// the rendering context
-
 		LPDIRECT3DVERTEXDECLARATION9 m_dwBranchVertexShader;			// branch/frond vertex shaders	
 		LPDIRECT3DVERTEXDECLARATION9 m_pLeafVertexShaderDecl;			// leaf vertex shader declaration
 		LPDIRECT3DVERTEXSHADER9		 m_pLeafVertexShader;			// leaf vertex shader

--- a/Lead-Client-Source/SpeedTreeLib/SpeedTreeWrapper.cpp
+++ b/Lead-Client-Source/SpeedTreeLib/SpeedTreeWrapper.cpp
@@ -94,7 +94,7 @@ void CSpeedTreeWrapper::OnRenderPCBlocker()
 {
 	if (ms_dwBranchVertexShader == 0)
 	{
-		ms_dwBranchVertexShader = LoadBranchShader(ms_lpd3dDevice);
+		ms_dwBranchVertexShader = LoadBranchShader();
 		//LogBox("Vertex Shader not assigned. You must call CSpeedTreeWrapper::SetVertexShader for this");
 	}
 	
@@ -237,7 +237,7 @@ void CSpeedTreeWrapper::OnRender()
 {
 	if (ms_dwBranchVertexShader == 0)
 	{
-		ms_dwBranchVertexShader = LoadBranchShader(ms_lpd3dDevice);
+		ms_dwBranchVertexShader = LoadBranchShader();
 		//LogBox("Vertex Shader not assigned. You must call CSpeedTreeWrapper::SetVertexShader for this");
 	}
 	

--- a/Lead-Client-Source/SpeedTreeLib/VertexShaders.h
+++ b/Lead-Client-Source/SpeedTreeLib/VertexShaders.h
@@ -31,6 +31,7 @@
 
 #pragma once
 #include "SpeedTreeConfig.h"
+#include "../eterlib/StateManager.h"
 #include <map>
 #include <string>
 
@@ -126,7 +127,7 @@ static const char g_achSimpleVertexProgram[] =
 ///////////////////////////////////////////////////////////////////////  
 //	LoadBranchShader
 
-static LPDIRECT3DVERTEXDECLARATION9 LoadBranchShader(LPDIRECT3DDEVICE9 pDx)
+static LPDIRECT3DVERTEXDECLARATION9 LoadBranchShader()
 {
 	// branch shader declaration
 	D3DVERTEXELEMENT9 pBranchShaderDecl[] = {
@@ -140,7 +141,7 @@ static LPDIRECT3DVERTEXDECLARATION9 LoadBranchShader(LPDIRECT3DDEVICE9 pDx)
 	// assemble shader
 	LPDIRECT3DVERTEXDECLARATION9 dwShader = NULL;
 
-	if (pDx->CreateVertexDeclaration(pBranchShaderDecl, &dwShader) != D3D_OK)
+	if (STATEMANAGER.CreateVertexDeclaration(pBranchShaderDecl, &dwShader) != D3D_OK)
 	{
 		char szError[1024];
 		sprintf_s(szError, "Failed to create branch vertex shader.");
@@ -257,7 +258,7 @@ static const char g_achLeafVertexProgram[] =
 ///////////////////////////////////////////////////////////////////////  
 //	LoadLeafShader
 
-static void LoadLeafShader(LPDIRECT3DDEVICE9 pDx, LPDIRECT3DVERTEXDECLARATION9& pVertexDecl, LPDIRECT3DVERTEXSHADER9& pVertexShader)
+static void LoadLeafShader(LPDIRECT3DVERTEXDECLARATION9& pVertexDecl, LPDIRECT3DVERTEXSHADER9& pVertexShader)
 {
     SAFE_RELEASE(pVertexDecl);
     SAFE_RELEASE(pVertexShader);
@@ -282,7 +283,7 @@ static void LoadLeafShader(LPDIRECT3DDEVICE9 pDx, LPDIRECT3DVERTEXDECLARATION9& 
 
     LPD3DXBUFFER pCode = nullptr, pError = nullptr;
     if (D3DXAssembleShader(g_achLeafVertexProgram, sizeof(g_achLeafVertexProgram) - 1, nullptr, nullptr, 0, &pCode, &pError) == D3D_OK) {
-        if (pDx->CreateVertexShader((DWORD*)pCode->GetBufferPointer(), &pVertexShader) != D3D_OK) {
+        if (STATEMANAGER.CreateVertexShader((DWORD*)pCode->GetBufferPointer(), &pVertexShader) != D3D_OK) {
             TraceError("Failed to create leaf vertex shader.");
         }
     }
@@ -290,7 +291,7 @@ static void LoadLeafShader(LPDIRECT3DDEVICE9 pDx, LPDIRECT3DVERTEXDECLARATION9& 
         TraceError("Failed to assemble leaf vertex shader. The error reported is [ %s ].", pError->GetBufferPointer());
     }
 
-    if (FAILED(pDx->CreateVertexDeclaration(leafVertexDecl, &pVertexDecl))) {
+    if (FAILED(STATEMANAGER.CreateVertexDeclaration(leafVertexDecl, &pVertexDecl))) {
         TraceError("Failed to create leaf vertex declaration");
     }
 

--- a/Lead-Client-Source/UserInterface/PythonSystem.cpp
+++ b/Lead-Client-Source/UserInterface/PythonSystem.cpp
@@ -456,6 +456,8 @@ bool CPythonSystem::LoadConfig()
 			m_Config.bShowDamage = atoi(value) == 1 ? true : false;
 		else if (!_stricmp(command, "SHOW_SALESTEXT"))
 			m_Config.bShowSalesText = atoi(value) == 1 ? true : false;
+		else if (!_stricmp(command, "SHADER_FFP"))
+			CGraphicBase::SetUseShaderFFP(atoi(value) == 1 ? true : false);
 	}
 
 	if (m_Config.bWindowed)


### PR DESCRIPTION
Phase 4: converts unlit 3D draws behind SHADER_FFP — ground decals (texture passthrough), weapon trails (runtime texture-or-diffuse select), fly trails (diffuse), lens flare (new rgb=tex*diffuse/alpha=tex variant + modulate rings). FFP fallback intact.

A/B: weapon swing trail, arrow trail, sun flare, ground decals pixel-identical.
Depends on #190 (shader pool; merged in).