### PR TITLE
fix(client): guard divide-by-zero in frame statistics

### DIFF
--- a/Lead-Client-Source/UserInterface/PythonApplication.cpp
+++ b/Lead-Client-Source/UserInterface/PythonApplication.cpp
@@ -493,7 +493,8 @@ bool CPythonApplication::Process()
 					m_dwFaceAccCount += dwCurFaceCount;
 					m_dwFaceAccTime += m_dwCurRenderTime;
 
-					m_fFaceSpd=static_cast<float>(m_dwFaceAccCount/m_dwFaceAccTime);
+					if (m_dwFaceAccTime > 0)
+						m_fFaceSpd=static_cast<float>(m_dwFaceAccCount/m_dwFaceAccTime);
 
 					// Distance automatic adjustment
 					if (-1 == m_iForceSightRange)


### PR DESCRIPTION
CPythonApplication::Process divides the accumulated face count by the accumulated render time every frame. When all frames so far rendered in under 1 ms (light scenes, e.g. character select on fast machines) the accumulator is still 0 and the integer division kills the process (0xc0000094), with no dialog or log.

Guard the division; m_fFaceSpd keeps its previous value until real timing data exists. Pre-existing bug, unrelated to the DX12 work.