### PR TITLE
fix(client): terrain flicker and dark room margins on block-built dungeon maps

### DIFF
--- a/Lead-Client-Source/GameLib/MapOutdoorRenderHTP.cpp
+++ b/Lead-Client-Source/GameLib/MapOutdoorRenderHTP.cpp
@@ -608,6 +608,11 @@ void CMapOutdoor::__HardwareTransformPatch_RenderPatchSplat(long patchnum, WORD 
 		STATEMANAGER.SetRenderState(D3DRS_FOGCOLOR, 0xFFFFFFFF);
 		STATEMANAGER.SetRenderState(D3DRS_SRCBLEND, D3DBLEND_ZERO);
 		STATEMANAGER.SetRenderState(D3DRS_DESTBLEND, D3DBLEND_SRCCOLOR);
+		// This overlay re-rasterizes the terrain mesh, so it must darken only the
+		// terrain's own pixels (bit-identical depths). With LESSEQUAL it also wins
+		// marginal depth fights against dungeon-block geometry lying on the
+		// terrain and multiplies whole blocks toward black for single frames.
+		STATEMANAGER.SaveRenderState(D3DRS_ZFUNC, D3DCMP_EQUAL);
 
 		D3DXMATRIX matShadowTexTransform;
 		D3DXMatrixMultiply(&matShadowTexTransform, &matTexTransform, &m_matStaticShadow);
@@ -662,6 +667,7 @@ void CMapOutdoor::__HardwareTransformPatch_RenderPatchSplat(long patchnum, WORD 
 		STATEMANAGER.SetSamplerState(0, D3DSAMP_ADDRESSV,  D3DTADDRESS_WRAP);
 		
 		
+		STATEMANAGER.RestoreRenderState(D3DRS_ZFUNC);
 		STATEMANAGER.SetRenderState(D3DRS_SRCBLEND, D3DBLEND_SRCALPHA);
 		STATEMANAGER.SetRenderState(D3DRS_DESTBLEND, D3DBLEND_INVSRCALPHA);
 		STATEMANAGER.SetRenderState(D3DRS_FOGCOLOR, dwFogColor);

--- a/Lead-Client-Source/UserInterface/PythonBackground.cpp
+++ b/Lead-Client-Source/UserInterface/PythonBackground.cpp
@@ -699,6 +699,11 @@ void CPythonBackground::RegisterDungeonMapName(const char * c_szMapName)
 	m_kSet_strDungeonMapName.insert(c_szMapName);
 }
 
+void CPythonBackground::RegisterBlockDungeonMapName(const char * c_szMapName)
+{
+	m_kSet_strBlockDungeonMapName.insert(c_szMapName);
+}
+
 CPythonBackground::TMapInfo* CPythonBackground::GlobalPositionToMapInfo(DWORD dwGlobalX, DWORD dwGlobalY)
 {
 	TMapInfoVector::iterator f = std::find_if(m_kVct_kMapInfo.begin(), m_kVct_kMapInfo.end(), FFindWarpMapName(dwGlobalX, dwGlobalY));
@@ -744,6 +749,15 @@ void CPythonBackground::Warp(DWORD dwX, DWORD dwY)
 
 		CMapOutdoor& rkMap=GetMapOutdoorRef();
 		rkMap.EnablePortal(TRUE);
+	}
+	else if (m_kSet_strBlockDungeonMapName.end() != m_kSet_strBlockDungeonMapName.find(m_strMapName))
+	{
+		// Block-built dungeon: the visible map is dungeon-block geometry laid over
+		// the heightmap, so hide the terrain (its dark shadow overlay leaks through
+		// at the room margins) but keep object heights - the floors are blocks
+		// sitting above the terrain, unlike the classic dungeon maps above.
+		CMapOutdoor& rkMap=GetMapOutdoorRef();
+		rkMap.SetVisiblePart(CMapOutdoor::PART_TERRAIN, false);
 	}
 
 	m_kSet_iShowingPortalID.clear();

--- a/Lead-Client-Source/UserInterface/PythonBackground.h
+++ b/Lead-Client-Source/UserInterface/PythonBackground.h
@@ -124,6 +124,7 @@ public:
 	void DisableGuildArea();
 
 	void RegisterDungeonMapName(const char * c_szMapName);
+	void RegisterBlockDungeonMapName(const char * c_szMapName);
 	TMapInfo* GlobalPositionToMapInfo(DWORD dwGlobalX, DWORD dwGlobalY);
 	const char* GetWarpMapName();
 
@@ -154,6 +155,7 @@ private:
 
 	std::set<int> m_kSet_iShowingPortalID;
 	std::set<std::string> m_kSet_strDungeonMapName;
+	std::set<std::string> m_kSet_strBlockDungeonMapName;
 	std::map<DWORD, DWORD> m_kMap_dwTargetID_dwChrID;
 
 	struct SReserveTargetEffect

--- a/Lead-Client-Source/UserInterface/PythonBackgroundModule.cpp
+++ b/Lead-Client-Source/UserInterface/PythonBackgroundModule.cpp
@@ -511,6 +511,16 @@ PyObject * backgroundRegisterDungeonMapName(PyObject * poSelf, PyObject * poArgs
 	return Py_BuildNone();
 }
 
+PyObject * backgroundRegisterBlockDungeonMapName(PyObject * poSelf, PyObject * poArgs)
+{
+	char * szName;
+	if (!PyTuple_GetString(poArgs, 0, &szName))
+		return Py_BadArgument();
+
+	CPythonBackground::Instance().RegisterBlockDungeonMapName(szName);
+	return Py_BuildNone();
+}
+
 PyObject * backgroundVisibleGuildArea(PyObject * poSelf, PyObject * poArgs)
 {
 	CPythonBackground::Instance().VisibleGuildArea();
@@ -576,6 +586,7 @@ void initBackground()
 		{ "SetTransparentTree",					backgroundSetTransparentTree,				METH_VARARGS },
 		{ "SetXMasTree",						backgroundSetXMasTree,						METH_VARARGS },
 		{ "RegisterDungeonMapName",				backgroundRegisterDungeonMapName,			METH_VARARGS },
+		{ "RegisterBlockDungeonMapName",		backgroundRegisterBlockDungeonMapName,		METH_VARARGS },
 
 		{ "VisibleGuildArea",					backgroundVisibleGuildArea,					METH_VARARGS },
 		{ "DisableGuildArea",					backgroundDisableGuildArea,					METH_VARARGS },

--- a/Lead-Client/pack/root/introloading.py
+++ b/Lead-Client/pack/root/introloading.py
@@ -16,6 +16,18 @@ import playerSettingModule
 import stringCommander
 import emotion
 
+# Register at import time: when logging in directly on a dungeon map the map is
+# loaded before LoadData() runs, so registering there is too late for that login.
+background.RegisterDungeonMapName("metin2_map_spiderdungeon")
+background.RegisterDungeonMapName("metin2_map_monkeydungeon")
+background.RegisterDungeonMapName("metin2_map_monkeydungeon_02")
+background.RegisterDungeonMapName("metin2_map_monkeydungeon_03")
+background.RegisterDungeonMapName("metin2_map_deviltower1")
+# Block-built dungeons: hide the terrain under the blocks but keep object
+# heights - their floors are dungeon-block geometry above the heightmap.
+background.RegisterBlockDungeonMapName("metin2_map_spiderdungeon_02")
+background.RegisterBlockDungeonMapName("metin2_map_spiderdungeon_03")
+
 ####################################
 # Module loading distribution for faster execution
 ####################################


### PR DESCRIPTION
Fixes the black flickering/dark room margins on spider dungeon 2/3 (pre-existing, unrelated to the DX12 migration - reproduces on pre-migration builds).

- The terrain static-shadow multiply pass re-rasterizes the terrain with `ZFUNC=LESSEQUAL`, so on maps whose visible geometry is dungeon blocks laid over the heightmap it keeps winning marginal depth fights and multiplies whole rooms toward black for single frames. It now draws with `ZFUNC=EQUAL`, matching only the terrain's own bit-identical depths; field maps are unaffected.
- New `background.RegisterBlockDungeonMapName`: hides terrain rendering (`PART_TERRAIN`) while keeping object heights. Used for `metin2_map_spiderdungeon_02/_03`, whose floors are block geometry above the terrain - the classic `RegisterDungeonMapName` (terrain-only heights) makes characters sink into their floors.
- Dungeon map names are now also registered at `introloading` import time; registering in `LoadData()` is too late when logging in directly on a dungeon map.

Note: the root pack must be rebuilt for the `introloading.py` change to take effect at runtime.

Verified in spider dungeon 3: per-frame screen luminance flat over 8k frames (was oscillating 30+ percentage points of near-black coverage every 2-3 frames), room margins clean, characters stand on the block floors, field map a1 and teleports unaffected.