### PR TITLE
feat(client): renderer backend selection seam

### DIFF
--- a/Lead-Client-Source/EterLib/GrpDevice.cpp
+++ b/Lead-Client-Source/EterLib/GrpDevice.cpp
@@ -322,8 +322,29 @@ bool CGraphicDevice::__IsInDriverBlackList(D3D_CAdapterInfo& rkD3DAdapterInfo)
 	return ret;
 }
 
+static CGraphicDevice::EBackend gs_eRequestedBackend = CGraphicDevice::BACKEND_DX9;
+static CGraphicDevice::EBackend gs_eActiveBackend = CGraphicDevice::BACKEND_DX9;
+
+void CGraphicDevice::SetRequestedBackend(EBackend eBackend)
+{
+	gs_eRequestedBackend = eBackend;
+}
+
+CGraphicDevice::EBackend CGraphicDevice::GetBackend()
+{
+	return gs_eActiveBackend;
+}
+
 int CGraphicDevice::Create(HWND hWnd, int iHres, int iVres, bool Windowed, int /*iBit*/, int iReflashRate)
 {
+	if (BACKEND_DX12 == gs_eRequestedBackend)
+	{
+		// The DX12 backend is not implemented yet; stay on DX9 so a stray
+		// config entry can never leave the player without a device.
+		TraceError("RENDERER dx12 requested but the DX12 backend is not available yet; using dx9.");
+	}
+	gs_eActiveBackend = BACKEND_DX9;
+
 	int iRet = CREATE_OK;
 
 	Destroy();

--- a/Lead-Client-Source/EterLib/GrpDevice.h
+++ b/Lead-Client-Source/EterLib/GrpDevice.h
@@ -26,6 +26,17 @@ public:
 	CGraphicDevice();
 	virtual ~CGraphicDevice();
 
+	// Renderer backend selection seam: the DX12 backend plugs in here;
+	// until it exists every request resolves to DX9.
+	enum EBackend
+	{
+		BACKEND_DX9,
+		BACKEND_DX12,
+	};
+
+	static void		SetRequestedBackend(EBackend eBackend);
+	static EBackend	GetBackend();
+
 	void			InitBackBufferCount(UINT uBackBufferCount);
 
 	void			Destroy();

--- a/Lead-Client-Source/UserInterface/PythonSystem.cpp
+++ b/Lead-Client-Source/UserInterface/PythonSystem.cpp
@@ -1,5 +1,6 @@
 ﻿#include "StdAfx.h"
 #include "PythonSystem.h"
+#include "../EterLib/GrpDevice.h"
 #include "PythonApplication.h"
 
 #define DEFAULT_VALUE_ALWAYS_SHOW_NAME		true
@@ -307,6 +308,7 @@ void CPythonSystem::SetDefaultConfig()
 	m_Config.bAlwaysShowName	= DEFAULT_VALUE_ALWAYS_SHOW_NAME;
 	m_Config.bShowDamage		= true;
 	m_Config.bShowSalesText		= true;
+	m_Config.byRendererBackend = 0;
 }
 
 bool CPythonSystem::IsWindowed()
@@ -456,7 +458,12 @@ bool CPythonSystem::LoadConfig()
 			m_Config.bShowDamage = atoi(value) == 1 ? true : false;
 		else if (!_stricmp(command, "SHOW_SALESTEXT"))
 			m_Config.bShowSalesText = atoi(value) == 1 ? true : false;
+		else if (!_stricmp(command, "RENDERER"))
+			m_Config.byRendererBackend = _stricmp(value, "dx12") ? 0 : 1;
 	}
+
+	CGraphicDevice::SetRequestedBackend(
+		1 == m_Config.byRendererBackend ? CGraphicDevice::BACKEND_DX12 : CGraphicDevice::BACKEND_DX9);
 
 	if (m_Config.bWindowed)
 	{

--- a/Lead-Client-Source/UserInterface/PythonSystem.h
+++ b/Lead-Client-Source/UserInterface/PythonSystem.h
@@ -75,6 +75,7 @@ class CPythonSystem : public CSingleton<CPythonSystem>
 			bool			bAlwaysShowName;
 			bool			bShowDamage;
 			bool			bShowSalesText;
+			BYTE			byRendererBackend;
 		} TConfig;
 
 	public:


### PR DESCRIPTION
RENDERER dx9|dx12 config key + device backend enum; dx12 requests fall back to dx9 until the backend lands. No dependencies.