### PR TITLE
feat(client): DX12 descriptor ring

### DIFF
--- a/Lead-Client-Source/EterLib/EterLib.vcxproj
+++ b/Lead-Client-Source/EterLib/EterLib.vcxproj
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+﻿<?xml version='1.0' encoding='utf-8'?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build" ToolsVersion="Current">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
@@ -152,6 +152,7 @@
     <ClCompile Include="GrpD3DXBuffer.cpp" />
     <ClCompile Include="GrpDetector.cpp" />
     <ClCompile Include="GrpDevice.cpp" />
+    <ClCompile Include="GrpDescriptorRingDX12.cpp" />
     <ClCompile Include="GrpDIB.cpp" />
     <ClCompile Include="GrpExpandedImageInstance.cpp" />
     <ClCompile Include="GrpFontTexture.cpp" />
@@ -227,6 +228,7 @@
     <ClInclude Include="GrpD3DXBuffer.h" />
     <ClInclude Include="GrpDetector.h" />
     <ClInclude Include="GrpDevice.h" />
+    <ClInclude Include="GrpDescriptorRingDX12.h" />
     <ClInclude Include="GrpDIB.h" />
     <ClInclude Include="GrpExpandedImageInstance.h" />
     <ClInclude Include="GrpFontTexture.h" />

--- a/Lead-Client-Source/EterLib/EterLib.vcxproj.filters
+++ b/Lead-Client-Source/EterLib/EterLib.vcxproj.filters
@@ -19,6 +19,7 @@
     <ClCompile Include="GrpD3DXBuffer.cpp" />
     <ClCompile Include="GrpDetector.cpp" />
     <ClCompile Include="GrpDevice.cpp" />
+    <ClCompile Include="GrpDescriptorRingDX12.cpp" />
     <ClCompile Include="GrpDIB.cpp" />
     <ClCompile Include="GrpExpandedImageInstance.cpp" />
     <ClCompile Include="GrpFontTexture.cpp" />
@@ -91,6 +92,7 @@
     <ClInclude Include="GrpD3DXBuffer.h" />
     <ClInclude Include="GrpDetector.h" />
     <ClInclude Include="GrpDevice.h" />
+    <ClInclude Include="GrpDescriptorRingDX12.h" />
     <ClInclude Include="GrpDIB.h" />
     <ClInclude Include="GrpExpandedImageInstance.h" />
     <ClInclude Include="GrpFontTexture.h" />

--- a/Lead-Client-Source/EterLib/GrpDescriptorRingDX12.cpp
+++ b/Lead-Client-Source/EterLib/GrpDescriptorRingDX12.cpp
@@ -1,0 +1,126 @@
+#include "StdAfx.h"
+#include "../eterBase/Stl.h"
+#include "GrpDescriptorRingDX12.h"
+
+CGraphicDescriptorRingDX12::CGraphicDescriptorRingDX12()
+	: m_pkHeap(NULL)
+	, m_uCapacity(0)
+	, m_uIncrementSize(0)
+	, m_uHead(0)
+	, m_uTail(0)
+	, m_uSpanCount(0)
+{
+}
+
+CGraphicDescriptorRingDX12::~CGraphicDescriptorRingDX12()
+{
+	Destroy();
+}
+
+bool CGraphicDescriptorRingDX12::Create(ID3D12Device* pkDevice,
+										D3D12_DESCRIPTOR_HEAP_TYPE eHeapType,
+										UINT uDescriptorCapacity)
+{
+	Destroy();
+
+	D3D12_DESCRIPTOR_HEAP_DESC kHeapDesc = {};
+	kHeapDesc.Type = eHeapType;
+	kHeapDesc.NumDescriptors = uDescriptorCapacity;
+	kHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+
+	if (FAILED(pkDevice->CreateDescriptorHeap(&kHeapDesc, IID_PPV_ARGS(&m_pkHeap))))
+	{
+		TraceError("CGraphicDescriptorRingDX12: heap creation failed (type %d, %u descriptors).",
+				   static_cast<int>(eHeapType), uDescriptorCapacity);
+		return false;
+	}
+
+	m_uCapacity = uDescriptorCapacity;
+	m_uIncrementSize = pkDevice->GetDescriptorHandleIncrementSize(eHeapType);
+	m_uHead = 0;
+	m_uTail = 0;
+	m_uSpanCount = 0;
+	return true;
+}
+
+void CGraphicDescriptorRingDX12::Destroy()
+{
+	safe_release(m_pkHeap);
+	m_uCapacity = 0;
+	m_uIncrementSize = 0;
+	m_uHead = 0;
+	m_uTail = 0;
+	m_uSpanCount = 0;
+}
+
+ID3D12DescriptorHeap* CGraphicDescriptorRingDX12::GetHeap() const
+{
+	return m_pkHeap;
+}
+
+bool CGraphicDescriptorRingDX12::Allocate(UINT uDescriptorCount, TTable* pkTable)
+{
+	if (!m_pkHeap || !uDescriptorCount || uDescriptorCount > m_uCapacity)
+		return false;
+
+	UINT uStart = m_uHead;
+
+	// Tables must be contiguous; wrap when the heap tail cannot hold one.
+	if (uStart + uDescriptorCount > m_uCapacity)
+		uStart = 0;
+
+	// The region [tail, head) still belongs to in-flight frames.
+	if (m_uSpanCount > 0)
+	{
+		const bool bWrapped = uStart < m_uHead;
+		if (bWrapped && uStart + uDescriptorCount > m_uTail)
+		{
+			TraceError("CGraphicDescriptorRingDX12: ring exhausted (%u in flight).", m_uSpanCount);
+			return false;
+		}
+	}
+
+	pkTable->kCPUHandle = m_pkHeap->GetCPUDescriptorHandleForHeapStart();
+	pkTable->kCPUHandle.ptr += static_cast<SIZE_T>(uStart) * m_uIncrementSize;
+	pkTable->kGPUHandle = m_pkHeap->GetGPUDescriptorHandleForHeapStart();
+	pkTable->kGPUHandle.ptr += static_cast<UINT64>(uStart) * m_uIncrementSize;
+
+	m_uHead = uStart + uDescriptorCount;
+	return true;
+}
+
+void CGraphicDescriptorRingDX12::OnFrameSubmitted(UINT64 uFenceValue)
+{
+	if (m_uSpanCount >= MAX_SPANS)
+	{
+		// Merge the oldest span into its successor; memory only stays
+		// reserved longer, never gets freed early.
+		for (UINT u = 1; u < m_uSpanCount; ++u)
+			m_akSpans[u - 1] = m_akSpans[u];
+		--m_uSpanCount;
+	}
+
+	m_akSpans[m_uSpanCount].uHead = m_uHead;
+	m_akSpans[m_uSpanCount].uFenceValue = uFenceValue;
+	++m_uSpanCount;
+}
+
+void CGraphicDescriptorRingDX12::OnFrameCompleted(UINT64 uCompletedFenceValue)
+{
+	UINT uReleased = 0;
+	while (uReleased < m_uSpanCount && m_akSpans[uReleased].uFenceValue <= uCompletedFenceValue)
+	{
+		m_uTail = m_akSpans[uReleased].uHead;
+		++uReleased;
+	}
+
+	if (uReleased > 0)
+	{
+		for (UINT u = uReleased; u < m_uSpanCount; ++u)
+			m_akSpans[u - uReleased] = m_akSpans[u];
+		m_uSpanCount -= uReleased;
+	}
+
+	if (0 == m_uSpanCount)
+		m_uTail = m_uHead;
+}

--- a/Lead-Client-Source/EterLib/GrpDescriptorRingDX12.h
+++ b/Lead-Client-Source/EterLib/GrpDescriptorRingDX12.h
@@ -1,0 +1,52 @@
+#pragma once
+
+// Fenced ring over a shader-visible descriptor heap: per-draw SRV and sampler
+// tables are staged here, valid for the frame they were written in. Same span
+// bookkeeping as the upload ring, counted in descriptors instead of bytes.
+
+#include <d3d12.h>
+
+class CGraphicDescriptorRingDX12
+{
+	public:
+		struct TTable
+		{
+			D3D12_CPU_DESCRIPTOR_HANDLE	kCPUHandle;
+			D3D12_GPU_DESCRIPTOR_HANDLE	kGPUHandle;
+		};
+
+		CGraphicDescriptorRingDX12();
+		~CGraphicDescriptorRingDX12();
+
+		// eHeapType: CBV_SRV_UAV or SAMPLER; the heap is shader-visible.
+		bool	Create(ID3D12Device* pkDevice,
+					   D3D12_DESCRIPTOR_HEAP_TYPE eHeapType,
+					   UINT uDescriptorCapacity);
+		void	Destroy();
+
+		ID3D12DescriptorHeap*	GetHeap() const;
+
+		// Reserves uDescriptorCount contiguous slots; the caller writes the
+		// descriptors through kCPUHandle and binds the table at kGPUHandle.
+		bool	Allocate(UINT uDescriptorCount, TTable* pkTable);
+
+		void	OnFrameSubmitted(UINT64 uFenceValue);
+		void	OnFrameCompleted(UINT64 uCompletedFenceValue);
+
+	private:
+		struct TFrameSpan
+		{
+			UINT	uHead;
+			UINT64	uFenceValue;
+		};
+
+		enum { MAX_SPANS = 8 };
+
+		ID3D12DescriptorHeap*	m_pkHeap;
+		UINT					m_uCapacity;
+		UINT					m_uIncrementSize;
+		UINT					m_uHead;
+		UINT					m_uTail;
+		TFrameSpan				m_akSpans[MAX_SPANS];
+		UINT					m_uSpanCount;
+};


### PR DESCRIPTION
Fenced ring over a shader-visible descriptor heap for per-draw SRV/sampler tables. Standalone.