### PR TITLE
feat(client): DX12 sampler-table cache

### DIFF
--- a/Lead-Client-Source/EterLib/EterLib.vcxproj
+++ b/Lead-Client-Source/EterLib/EterLib.vcxproj
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+﻿<?xml version='1.0' encoding='utf-8'?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build" ToolsVersion="Current">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
@@ -152,6 +152,7 @@
     <ClCompile Include="GrpD3DXBuffer.cpp" />
     <ClCompile Include="GrpDetector.cpp" />
     <ClCompile Include="GrpDevice.cpp" />
+    <ClCompile Include="GrpSamplerKeyDX12.cpp" />
     <ClCompile Include="GrpDIB.cpp" />
     <ClCompile Include="GrpExpandedImageInstance.cpp" />
     <ClCompile Include="GrpFontTexture.cpp" />
@@ -227,6 +228,7 @@
     <ClInclude Include="GrpD3DXBuffer.h" />
     <ClInclude Include="GrpDetector.h" />
     <ClInclude Include="GrpDevice.h" />
+    <ClInclude Include="GrpSamplerKeyDX12.h" />
     <ClInclude Include="GrpDIB.h" />
     <ClInclude Include="GrpExpandedImageInstance.h" />
     <ClInclude Include="GrpFontTexture.h" />

--- a/Lead-Client-Source/EterLib/EterLib.vcxproj
+++ b/Lead-Client-Source/EterLib/EterLib.vcxproj
@@ -153,6 +153,7 @@
     <ClCompile Include="GrpDetector.cpp" />
     <ClCompile Include="GrpDevice.cpp" />
     <ClCompile Include="GrpSamplerKeyDX12.cpp" />
+    <ClCompile Include="GrpSamplerCacheDX12.cpp" />
     <ClCompile Include="GrpDIB.cpp" />
     <ClCompile Include="GrpExpandedImageInstance.cpp" />
     <ClCompile Include="GrpFontTexture.cpp" />
@@ -229,6 +230,7 @@
     <ClInclude Include="GrpDetector.h" />
     <ClInclude Include="GrpDevice.h" />
     <ClInclude Include="GrpSamplerKeyDX12.h" />
+    <ClInclude Include="GrpSamplerCacheDX12.h" />
     <ClInclude Include="GrpDIB.h" />
     <ClInclude Include="GrpExpandedImageInstance.h" />
     <ClInclude Include="GrpFontTexture.h" />

--- a/Lead-Client-Source/EterLib/EterLib.vcxproj.filters
+++ b/Lead-Client-Source/EterLib/EterLib.vcxproj.filters
@@ -20,6 +20,7 @@
     <ClCompile Include="GrpDetector.cpp" />
     <ClCompile Include="GrpDevice.cpp" />
     <ClCompile Include="GrpSamplerKeyDX12.cpp" />
+    <ClCompile Include="GrpSamplerCacheDX12.cpp" />
     <ClCompile Include="GrpDIB.cpp" />
     <ClCompile Include="GrpExpandedImageInstance.cpp" />
     <ClCompile Include="GrpFontTexture.cpp" />
@@ -93,6 +94,7 @@
     <ClInclude Include="GrpDetector.h" />
     <ClInclude Include="GrpDevice.h" />
     <ClInclude Include="GrpSamplerKeyDX12.h" />
+    <ClInclude Include="GrpSamplerCacheDX12.h" />
     <ClInclude Include="GrpDIB.h" />
     <ClInclude Include="GrpExpandedImageInstance.h" />
     <ClInclude Include="GrpFontTexture.h" />

--- a/Lead-Client-Source/EterLib/EterLib.vcxproj.filters
+++ b/Lead-Client-Source/EterLib/EterLib.vcxproj.filters
@@ -19,6 +19,7 @@
     <ClCompile Include="GrpD3DXBuffer.cpp" />
     <ClCompile Include="GrpDetector.cpp" />
     <ClCompile Include="GrpDevice.cpp" />
+    <ClCompile Include="GrpSamplerKeyDX12.cpp" />
     <ClCompile Include="GrpDIB.cpp" />
     <ClCompile Include="GrpExpandedImageInstance.cpp" />
     <ClCompile Include="GrpFontTexture.cpp" />
@@ -91,6 +92,7 @@
     <ClInclude Include="GrpD3DXBuffer.h" />
     <ClInclude Include="GrpDetector.h" />
     <ClInclude Include="GrpDevice.h" />
+    <ClInclude Include="GrpSamplerKeyDX12.h" />
     <ClInclude Include="GrpDIB.h" />
     <ClInclude Include="GrpExpandedImageInstance.h" />
     <ClInclude Include="GrpFontTexture.h" />

--- a/Lead-Client-Source/EterLib/GrpSamplerCacheDX12.cpp
+++ b/Lead-Client-Source/EterLib/GrpSamplerCacheDX12.cpp
@@ -1,0 +1,115 @@
+#include "StdAfx.h"
+#include "../eterBase/Stl.h"
+#include "GrpSamplerCacheDX12.h"
+
+CGraphicSamplerCacheDX12::CGraphicSamplerCacheDX12()
+	: m_pkDevice(NULL)
+	, m_pkHeap(NULL)
+	, m_uTableCapacity(0)
+	, m_uTableCount(0)
+	, m_uIncrementSize(0)
+{
+}
+
+CGraphicSamplerCacheDX12::~CGraphicSamplerCacheDX12()
+{
+	Destroy();
+}
+
+bool CGraphicSamplerCacheDX12::Create(ID3D12Device* pkDevice, UINT uTableCapacity)
+{
+	Destroy();
+
+	D3D12_DESCRIPTOR_HEAP_DESC kHeapDesc = {};
+	kHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER;
+	kHeapDesc.NumDescriptors = uTableCapacity * 2;
+	kHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+
+	if (FAILED(pkDevice->CreateDescriptorHeap(&kHeapDesc, IID_PPV_ARGS(&m_pkHeap))))
+	{
+		TraceError("CGraphicSamplerCacheDX12: heap creation failed (%u tables).", uTableCapacity);
+		return false;
+	}
+
+	m_pkDevice = pkDevice;
+	m_uTableCapacity = uTableCapacity;
+	m_uTableCount = 0;
+	m_uIncrementSize = pkDevice->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER);
+	return true;
+}
+
+void CGraphicSamplerCacheDX12::Destroy()
+{
+	safe_release(m_pkHeap);
+	m_kTableMap.clear();
+	m_pkDevice = NULL;
+	m_uTableCapacity = 0;
+	m_uTableCount = 0;
+	m_uIncrementSize = 0;
+}
+
+ID3D12DescriptorHeap* CGraphicSamplerCacheDX12::GetHeap() const
+{
+	return m_pkHeap;
+}
+
+bool CGraphicSamplerCacheDX12::GetTable(const CGraphicSamplerKeyDX12& rkKey0,
+										const CGraphicSamplerKeyDX12& rkKey1,
+										D3D12_GPU_DESCRIPTOR_HANDLE* pkTableOut)
+{
+	if (!m_pkHeap)
+		return false;
+
+	const UINT64 uHash0 = rkKey0.Hash();
+	const UINT64 uHash1 = rkKey1.Hash();
+	const UINT64 uCombined = uHash0 * 1099511628211ULL ^ uHash1;
+
+	std::vector<TEntry>& rkChain = m_kTableMap[uCombined];
+
+	UINT uTableIndex = 0xFFFFFFFF;
+	for (size_t uPos = 0; uPos != rkChain.size(); ++uPos)
+	{
+		if (rkChain[uPos].uHash0 == uHash0 && rkChain[uPos].uHash1 == uHash1)
+		{
+			uTableIndex = rkChain[uPos].uTableIndex;
+			break;
+		}
+	}
+
+	if (0xFFFFFFFF == uTableIndex)
+	{
+		if (m_uTableCount >= m_uTableCapacity)
+		{
+			TraceError("CGraphicSamplerCacheDX12: heap full (%u tables).", m_uTableCapacity);
+			return false;
+		}
+
+		uTableIndex = m_uTableCount++;
+
+		D3D12_CPU_DESCRIPTOR_HANDLE kWriteHandle = m_pkHeap->GetCPUDescriptorHandleForHeapStart();
+		kWriteHandle.ptr += static_cast<SIZE_T>(uTableIndex) * 2 * m_uIncrementSize;
+
+		D3D12_SAMPLER_DESC kSamplerDesc;
+		rkKey0.ToSamplerDesc(&kSamplerDesc);
+		m_pkDevice->CreateSampler(&kSamplerDesc, kWriteHandle);
+
+		kWriteHandle.ptr += m_uIncrementSize;
+		rkKey1.ToSamplerDesc(&kSamplerDesc);
+		m_pkDevice->CreateSampler(&kSamplerDesc, kWriteHandle);
+
+		TEntry kEntry;
+		kEntry.uHash0 = uHash0;
+		kEntry.uHash1 = uHash1;
+		kEntry.uTableIndex = uTableIndex;
+		rkChain.push_back(kEntry);
+	}
+
+	*pkTableOut = m_pkHeap->GetGPUDescriptorHandleForHeapStart();
+	pkTableOut->ptr += static_cast<UINT64>(uTableIndex) * 2 * m_uIncrementSize;
+	return true;
+}
+
+UINT CGraphicSamplerCacheDX12::GetCount() const
+{
+	return m_uTableCount;
+}

--- a/Lead-Client-Source/EterLib/GrpSamplerCacheDX12.h
+++ b/Lead-Client-Source/EterLib/GrpSamplerCacheDX12.h
@@ -1,0 +1,50 @@
+#pragma once
+
+// Persistent sampler-table cache: each unique pair of stage-0/stage-1 sampler
+// keys gets two adjacent descriptors in a shader-visible heap, written once
+// and rebound by GPU handle. Sampler heaps are tiny (2048 max), so entries
+// live for the device lifetime.
+
+#include <d3d12.h>
+#include <unordered_map>
+#include <vector>
+
+#include "GrpSamplerKeyDX12.h"
+
+class CGraphicSamplerCacheDX12
+{
+	public:
+		CGraphicSamplerCacheDX12();
+		~CGraphicSamplerCacheDX12();
+
+		bool	Create(ID3D12Device* pkDevice, UINT uTableCapacity);
+		void	Destroy();
+
+		ID3D12DescriptorHeap*	GetHeap() const;
+
+		// GPU handle of the s0+s1 table for the key pair; writes the two
+		// descriptors on first sight. Fails once the heap is full.
+		bool	GetTable(const CGraphicSamplerKeyDX12& rkKey0,
+						 const CGraphicSamplerKeyDX12& rkKey1,
+						 D3D12_GPU_DESCRIPTOR_HANDLE* pkTableOut);
+
+		UINT	GetCount() const;
+
+	private:
+		struct TEntry
+		{
+			UINT64	uHash0;
+			UINT64	uHash1;
+			UINT	uTableIndex;
+		};
+
+		// Chained on both key hashes so combined-hash collisions stay correct.
+		typedef std::unordered_map<UINT64, std::vector<TEntry> > TTableMap;
+
+		ID3D12Device*			m_pkDevice;
+		ID3D12DescriptorHeap*	m_pkHeap;
+		UINT					m_uTableCapacity;
+		UINT					m_uTableCount;
+		UINT					m_uIncrementSize;
+		TTableMap				m_kTableMap;
+};

--- a/Lead-Client-Source/EterLib/GrpSamplerKeyDX12.cpp
+++ b/Lead-Client-Source/EterLib/GrpSamplerKeyDX12.cpp
@@ -1,0 +1,90 @@
+#include "StdAfx.h"
+#include "GrpSamplerKeyDX12.h"
+#include "StateManager.h"
+
+CGraphicSamplerKeyDX12::CGraphicSamplerKeyDX12()
+{
+	Reset();
+}
+
+void CGraphicSamplerKeyDX12::Reset()
+{
+	m_uMinFilter = D3DTEXF_POINT;
+	m_uMagFilter = D3DTEXF_POINT;
+	m_uMipFilter = D3DTEXF_NONE;
+	m_uAddressU = D3DTADDRESS_WRAP;
+	m_uAddressV = D3DTADDRESS_WRAP;
+	m_uMaxAnisotropy = 1;
+}
+
+void CGraphicSamplerKeyDX12::Capture(CStateManager& rkStateManager, DWORD dwStage)
+{
+	rkStateManager.GetSamplerState(dwStage, D3DSAMP_MINFILTER, &m_uMinFilter);
+	rkStateManager.GetSamplerState(dwStage, D3DSAMP_MAGFILTER, &m_uMagFilter);
+	rkStateManager.GetSamplerState(dwStage, D3DSAMP_MIPFILTER, &m_uMipFilter);
+	rkStateManager.GetSamplerState(dwStage, D3DSAMP_ADDRESSU, &m_uAddressU);
+	rkStateManager.GetSamplerState(dwStage, D3DSAMP_ADDRESSV, &m_uAddressV);
+	rkStateManager.GetSamplerState(dwStage, D3DSAMP_MAXANISOTROPY, &m_uMaxAnisotropy);
+}
+
+UINT64 CGraphicSamplerKeyDX12::Hash() const
+{
+	// Six fields with small value ranges pack into one word directly.
+	return static_cast<UINT64>(m_uMinFilter & 0xFF)
+		| (static_cast<UINT64>(m_uMagFilter & 0xFF) << 8)
+		| (static_cast<UINT64>(m_uMipFilter & 0xFF) << 16)
+		| (static_cast<UINT64>(m_uAddressU & 0xFF) << 24)
+		| (static_cast<UINT64>(m_uAddressV & 0xFF) << 32)
+		| (static_cast<UINT64>(m_uMaxAnisotropy & 0xFF) << 40);
+}
+
+bool CGraphicSamplerKeyDX12::operator==(const CGraphicSamplerKeyDX12& rkKey) const
+{
+	return Hash() == rkKey.Hash();
+}
+
+void CGraphicSamplerKeyDX12::ToSamplerDesc(D3D12_SAMPLER_DESC* pkDesc) const
+{
+	memset(pkDesc, 0, sizeof(*pkDesc));
+
+	if (D3DTEXF_ANISOTROPIC == m_uMinFilter || D3DTEXF_ANISOTROPIC == m_uMagFilter)
+	{
+		pkDesc->Filter = D3D12_FILTER_ANISOTROPIC;
+	}
+	else
+	{
+		// D3D12 basic filters encode as bits: mip 0x1, mag 0x4, min 0x10.
+		UINT uFilter = 0;
+		if (D3DTEXF_LINEAR == m_uMinFilter)
+			uFilter |= 0x10;
+		if (D3DTEXF_LINEAR == m_uMagFilter)
+			uFilter |= 0x04;
+		if (D3DTEXF_LINEAR == m_uMipFilter)
+			uFilter |= 0x01;
+		pkDesc->Filter = static_cast<D3D12_FILTER>(uFilter);
+	}
+
+	pkDesc->AddressU = ToAddressModeDX12(m_uAddressU);
+	pkDesc->AddressV = ToAddressModeDX12(m_uAddressV);
+	pkDesc->AddressW = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+	pkDesc->MipLODBias = 0.0f;
+	pkDesc->MaxAnisotropy = m_uMaxAnisotropy < 1 ? 1 : m_uMaxAnisotropy;
+	pkDesc->ComparisonFunc = D3D12_COMPARISON_FUNC_NEVER;
+	pkDesc->MinLOD = 0.0f;
+
+	// D3DTEXF_NONE disables mipmapping; clamping to the top level matches.
+	pkDesc->MaxLOD = (D3DTEXF_NONE == m_uMipFilter) ? 0.0f : D3D12_FLOAT32_MAX;
+}
+
+D3D12_TEXTURE_ADDRESS_MODE CGraphicSamplerKeyDX12::ToAddressModeDX12(DWORD dwAddressD3D9)
+{
+	switch (dwAddressD3D9)
+	{
+		case D3DTADDRESS_WRAP:			return D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+		case D3DTADDRESS_MIRROR:		return D3D12_TEXTURE_ADDRESS_MODE_MIRROR;
+		case D3DTADDRESS_CLAMP:			return D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
+		case D3DTADDRESS_BORDER:		return D3D12_TEXTURE_ADDRESS_MODE_BORDER;
+		case D3DTADDRESS_MIRRORONCE:	return D3D12_TEXTURE_ADDRESS_MODE_MIRROR_ONCE;
+	}
+	return D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+}

--- a/Lead-Client-Source/EterLib/GrpSamplerKeyDX12.h
+++ b/Lead-Client-Source/EterLib/GrpSamplerKeyDX12.h
@@ -1,0 +1,37 @@
+#pragma once
+
+// D3D9 sampler-state snapshot for one texture stage and its translation to a
+// D3D12_SAMPLER_DESC. Hashable so the backend's sampler-descriptor cache
+// creates each unique filter/address combination once.
+
+#include <d3d12.h>
+
+class CStateManager;
+
+class CGraphicSamplerKeyDX12
+{
+	public:
+		CGraphicSamplerKeyDX12();
+
+		void	Reset();
+
+		void	Capture(CStateManager& rkStateManager, DWORD dwStage);
+
+		UINT64	Hash() const;
+
+		bool	operator==(const CGraphicSamplerKeyDX12& rkKey) const;
+
+		void	ToSamplerDesc(D3D12_SAMPLER_DESC* pkDesc) const;
+
+		static D3D12_TEXTURE_ADDRESS_MODE	ToAddressModeDX12(DWORD dwAddressD3D9);
+
+	public:
+		// Raw D3DTEXTUREFILTERTYPE / D3DTEXTUREADDRESS values; DWORD because
+		// CStateManager::GetSamplerState fills them through DWORD pointers.
+		DWORD	m_uMinFilter;
+		DWORD	m_uMagFilter;
+		DWORD	m_uMipFilter;
+		DWORD	m_uAddressU;
+		DWORD	m_uAddressV;
+		DWORD	m_uMaxAnisotropy;
+};


### PR DESCRIPTION
Persistent shader-visible sampler heap; each unique s0+s1 key pair written once, rebound by GPU handle. Dep #224; its commits vanish once it lands.